### PR TITLE
[functionality] add pack support for position of customCTkButton

### DIFF
--- a/customtkinter/customtkinter_button.py
+++ b/customtkinter/customtkinter_button.py
@@ -30,6 +30,8 @@ class CTkButton(tkinter.Frame):
 
         AppearanceModeTracker.add(self.set_appearance_mode)
 
+        self.gridConfigure()
+
         if bg_color is None:
             if isinstance(self.master, CTkFrame):
                 self.bg_color = self.master.fg_color
@@ -49,10 +51,10 @@ class CTkButton(tkinter.Frame):
         self.width = width
         self.height = height
 
-        if corner_radius*2 > self.height:
-            self.corner_radius = self.height/2
-        elif corner_radius*2 > self.width:
-            self.corner_radius = self.width/2
+        if corner_radius * 2 > self.height:
+            self.corner_radius = self.height / 2
+        elif corner_radius * 2 > self.width:
+            self.corner_radius = self.width / 2
         else:
             self.corner_radius = corner_radius
 
@@ -89,7 +91,7 @@ class CTkButton(tkinter.Frame):
                                      highlightthicknes=0,
                                      width=self.width,
                                      height=self.height)
-        self.canvas.place(x=0, y=0)
+        self.canvas.grid(row=0, column=0)
 
         if self.hover is True:
             self.canvas.bind("<Enter>", self.on_enter)
@@ -103,6 +105,20 @@ class CTkButton(tkinter.Frame):
         self.text_label = None
         self.image_label = None
 
+        # Each time an item is resized due to pack position mode, the binding Configure is called on the widget
+        self.bind('<Configure>', self.updateDimensions)
+        self.draw()
+
+    def gridConfigure(self):
+        # Configuration of a basic grid  in which all elements of CTkButtons are centered on one row and one column
+        self.grid_rowconfigure(0, weight=1)
+        self.grid_columnconfigure(0, weight=1)
+
+    def updateDimensions(self, event):
+        # We update the dimensions of the internal elements of CTkButton Widget
+        self.canvas.config(width=event.width, height=event.height)
+        self.width = event.width
+        self.height = event.height
         self.draw()
 
     def draw(self):
@@ -200,7 +216,7 @@ class CTkButton(tkinter.Frame):
             self.text_label = tkinter.Label(master=self,
                                             text=self.text,
                                             font=self.text_font)
-            self.text_label.place(relx=0.5, rely=0.5, anchor=tkinter.CENTER)
+            self.text_label.grid(row=0, column=0)
 
             self.text_label.bind("<Enter>", self.on_enter)
             self.text_label.bind("<Leave>", self.on_leave)
@@ -230,7 +246,7 @@ class CTkButton(tkinter.Frame):
         else:
             self.image_label = tkinter.Label(master=self,
                                              image=self.image)
-            self.image_label.place(relx=0.5, rely=0.5, anchor=tkinter.CENTER)
+            self.image_label.grid(row=0, column=0)
 
             self.image_label.bind("<Enter>", self.on_enter)
             self.image_label.bind("<Leave>", self.on_leave)
@@ -362,4 +378,3 @@ class CTkButton(tkinter.Frame):
             self.appearance_mode = 0
 
         self.draw()
-


### PR DESCRIPTION
**I think it would be nice to provide pack() function for positionning customTkinter widgets.** It will prodive more flexibility and more possibility of placement.
I needed this for my project in order to make buttons which "fill" all the available spaces. It was not possible with place() method.

So with the changes I can now do:
```python
button_1 = customtkinter.CTkButton(master=root_tk, corner_radius=10, command=button_function, text="Auto expanded button")
button_1.pack(expand=1, fill=tkinter.BOTH, padx=20, pady=20)

button_2 = customtkinter.CTkButton(master=root_tk, corner_radius=10, text="normal button")
button_2.pack(pady=20)
```
![image](https://user-images.githubusercontent.com/31690836/140352708-36fe7dc9-324c-4aef-b685-a0373732affb.png)

Note that it we want to keep a CTkFrame around the button, and we don't want the CTkFrame to shrink, we can provide pack_propagate(0) to keep expected result:

```python
frame_1 = customtkinter.CTkFrame(master=root_tk, width=300, height=260, corner_radius=15)
frame_1.place(relx=0.5, rely=0.5, anchor=tkinter.CENTER)
frame_1.pack_propagate(0)

button_1 = customtkinter.CTkButton(master=frame_1, corner_radius=10, command=button_function, text="Auto expanded button")
button_1.pack(expand=1, fill=tkinter.BOTH, padx=20, pady=20)

button_2 = customtkinter.CTkButton(master=frame_1, corner_radius=10, text="normal button")
button_2.pack(pady=20)
```
![image](https://user-images.githubusercontent.com/31690836/140354451-23c0c196-9ba2-4fa0-98a4-4492eb4cb2a2.png)


To do this, in the code (inside CTkButton file) i changed from place() to grid() placement.

I think this modification could be made on all CTkWidgets, let me know if you are interested. I have time to work on this on all the widgets if you think it could be interesting.
