### PR TITLE
Fixed loading fonts on linux

### DIFF
--- a/customtkinter/font_manager.py
+++ b/customtkinter/font_manager.py
@@ -51,7 +51,7 @@ class FontManager:
             return cls.windows_load_font(font_path, private=True, enumerable=False)
 
         # Linux
-        elif sys.platform.startswith("win"):
+        elif sys.platform.startswith("linux"):
             try:
                 shutil.copy(font_path, os.path.expanduser("~/.fonts/"))
                 return True


### PR DESCRIPTION
Hi! Just a minor fix. Kept getting this warning "customtkinter.__init__ warning: Preferred drawing method 'font_shapes' can not be used because the font file could not be loaded.
Using 'circle_shapes' instead. The rendering quality will be bad!". This change fixes it.