### PR TITLE
Remove title-bar from dropdown on Mac

### DIFF
--- a/customtkinter/widgets/dropdown_menu.py
+++ b/customtkinter/widgets/dropdown_menu.py
@@ -56,7 +56,6 @@ class DropdownMenu(tkinter.Toplevel):
 
         if sys.platform.startswith("darwin"):
             self.overrideredirect(True)  # remove title-bar
-            self.overrideredirect(False)
             self.wm_attributes("-transparent", True)  # turn off window shadow
             self.config(bg='systemTransparent')  # transparent bg
             self.frame = customtkinter.CTkFrame(self,


### PR DESCRIPTION
I think this this should fix #149 . Here's a screenshot of what my dropdown menu now looks like...
![image](https://user-images.githubusercontent.com/66489361/173196570-948a84b5-cf5b-4a82-966b-c173e861c8c8.png)
I'm running macOS Big Sur Version 11.4 and python 3.10.5 .

Hope that helps!