### PR TITLE
Fix scrollbar issue

### DIFF
--- a/customtkinter/assets/themes/dark-blue.json
+++ b/customtkinter/assets/themes/dark-blue.json
@@ -72,6 +72,8 @@
     "switch_border_width": 3,
     "switch_corner_radius": 1000,
     "switch_button_corner_radius": 1000,
-    "switch_button_length": 0
+    "switch_button_length": 0,
+    "scrollbar_corner_radius": 1000,
+    "scrollbar_border_spacing": 4
   }
 }

--- a/customtkinter/assets/themes/green.json
+++ b/customtkinter/assets/themes/green.json
@@ -72,6 +72,8 @@
     "switch_border_width": 3,
     "switch_corner_radius": 1000,
     "switch_button_corner_radius": 1000,
-    "switch_button_length": 0
+    "switch_button_length": 0,
+    "scrollbar_corner_radius": 1000,
+    "scrollbar_border_spacing": 4
   }
 }

--- a/customtkinter/assets/themes/sweetkind.json
+++ b/customtkinter/assets/themes/sweetkind.json
@@ -72,6 +72,8 @@
     "switch_border_width": 3,
     "switch_corner_radius": 1000,
     "switch_button_corner_radius": 1000,
-    "switch_button_length": 2
+    "switch_button_length": 2,
+    "scrollbar_corner_radius": 1000,
+    "scrollbar_border_spacing": 4
   }
 }


### PR DESCRIPTION
[Themes](https://github.com/TomSchimansky/CustomTkinter/tree/master/customtkinter/assets/themes) (green, sweetkind and darkblue) other than **blue** have missing configs `scrollbar_corner_radius` and `scrollbar_border_spacing` 
which causes below exception :- 
```Exception in thread Thread-2:
Traceback (most recent call last):
  File "/usr/lib/python3.9/threading.py", line 954, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.9/threading.py", line 892, in run
    self._target(*self._args, **self._kwargs)

  File "/home/ripe/..........gui/about.py", line 35, in __init__
    ctk_textbox_scrollbar = customtkinter.CTkScrollbar(self.frame, command=tk_textbox.yview)
  File "/home/ripe/........../lib/python3.9/site-packages/customtkinter/widgets/ctk_scrollbar.py", line 46, in __init__
    self.corner_radius = ThemeManager.theme["shape"]["scrollbar_corner_radius"] if corner_radius == "default_theme" else corner_radius
KeyError: 'scrollbar_corner_radius'
```