### PR TITLE
Fix for issue #331

### DIFF
--- a/customtkinter/widgets/ctk_textbox.py
+++ b/customtkinter/widgets/ctk_textbox.py
@@ -153,6 +153,9 @@ class CTkTextbox(CTkBaseClass):
         if "border_width" in kwargs:
             self.border_width = kwargs.pop("border_width")
             require_redraw = True
+            
+        if 'state' in kwargs:
+            self.textbox.config(state=kwargs.pop('state'))
 
         if "width" in kwargs:
             self.set_dimensions(width=kwargs.pop("width"))


### PR DESCRIPTION
Issue: Cannot set state argument with CTkTextbox.config() / CTkTextbox.configure()

There is currently no way to change the state of the widget. This change (lines 157-158) allows this via the textbox.configure method. This fix implements the functionality.