### PR TITLE
name support for CTkEntry, CTkLabel, CTkTextbox

### DIFF
--- a/customtkinter/widgets/ctk_entry.py
+++ b/customtkinter/widgets/ctk_entry.py
@@ -24,10 +24,12 @@ class CTkEntry(CTkBaseClass):
                  **kwargs):
 
         # transfer basic functionality (bg_color, size, _appearance_mode, scaling) to CTkBaseClass
-        if "master" in kwargs:
-            super().__init__(*args, bg_color=bg_color, width=width, height=height, master=kwargs.pop("master"))
-        else:
-            super().__init__(*args, bg_color=bg_color, width=width, height=height)
+        super_kwargs = {}
+        if "master" in kwargs:      
+            super_kwargs['master'] = kwargs.pop("master")
+        if "name" in kwargs:
+            super_kwargs['name'] = kwargs.pop("name")
+        super().__init__(*args, bg_color=bg_color, width=width, height=height,**super_kwargs)
 
         # configure grid system (1x1)
         self.grid_rowconfigure(0, weight=1)

--- a/customtkinter/widgets/ctk_label.py
+++ b/customtkinter/widgets/ctk_label.py
@@ -21,11 +21,12 @@ class CTkLabel(CTkBaseClass):
                  **kwargs):
 
         # transfer basic functionality (bg_color, size, _appearance_mode, scaling) to CTkBaseClass
-        if "master" in kwargs:
-            super().__init__(*args, bg_color=bg_color, width=width, height=height, master=kwargs.pop("master"))
-        else:
-            super().__init__(*args, bg_color=bg_color, width=width, height=height)
-
+        super_kwargs = {}
+        if "master" in kwargs:      
+            super_kwargs['master'] = kwargs.pop("master")
+        if "name" in kwargs:
+            super_kwargs['name'] = kwargs.pop("name")
+        super().__init__(*args, bg_color=bg_color, width=width, height=height,**super_kwargs)
         # color
         self.fg_color = ThemeManager.theme["color"]["label"] if fg_color == "default_theme" else fg_color
         if self.fg_color is None:

--- a/customtkinter/widgets/ctk_textbox.py
+++ b/customtkinter/widgets/ctk_textbox.py
@@ -20,10 +20,12 @@ class CTkTextbox(CTkBaseClass):
                  **kwargs):
 
         # transfer basic functionality (bg_color, size, _appearance_mode, scaling) to CTkBaseClass
-        if "master" in kwargs:
-            super().__init__(*args, bg_color=bg_color, width=width, height=height, master=kwargs.pop("master"))
-        else:
-            super().__init__(*args, bg_color=bg_color, width=width, height=height)
+        super_kwargs = {}
+        if "master" in kwargs:      
+            super_kwargs['master'] = kwargs.pop("master")
+        if "name" in kwargs:
+            super_kwargs['name'] = kwargs.pop("name")
+        super().__init__(*args, bg_color=bg_color, width=width, height=height,**super_kwargs)
 
         # color
         self.fg_color = ThemeManager.theme["color"]["entry"] if fg_color == "default_theme" else fg_color


### PR DESCRIPTION
When you give either CTkEntry, CTkLabel, or CTkTextbox the `name` argument, the path names for those widgets become something like `.frame.!ctklabel`, with a child widget that has the actual name like `.frame.!ctklabel.my_widget_name`  This is a possible fix for that.