### PR TITLE
fixed get() and delete() function to CTkTextbox #602

### DIFF
--- a/customtkinter/widgets/ctk_textbox.py
+++ b/customtkinter/widgets/ctk_textbox.py
@@ -115,6 +115,12 @@ class CTkTextbox(CTkBaseClass):
     def xview(self, *args):
         return self.textbox.xview(*args)
 
+    def get(self, *args, **kwargs):
+        return self.textbox.get(*args, **kwargs)
+    
+    def delete(self, *args, **kwargs):
+        return self.textbox.delete(*args, **kwargs)
+    
     def insert(self, *args, **kwargs):
         return self.textbox.insert(*args, **kwargs)
 


### PR DESCRIPTION
basically wrote two call functions that were missed from tk.Text
there might be something else I missed but this is all that I've caught atm