### PR TITLE
Update ctk_button.py

### DIFF
--- a/customtkinter/windows/widgets/ctk_button.py
+++ b/customtkinter/windows/widgets/ctk_button.py
@@ -488,7 +488,8 @@ class CTkButton(CTkBaseClass):
 
             # set text_label bg color to button hover color
             if self._text_label is not None:
-                self._text_label.configure(bg=self._apply_appearance_mode(inner_parts_color))
+                self._text_label.configure(bg=self._apply_appearance_mode(inner_parts_color),
+                                           fg=self._apply_appearance_mode(self._fg_color))
 
             # set image_label bg color to button hover color
             if self._image_label is not None:
@@ -509,7 +510,8 @@ class CTkButton(CTkBaseClass):
 
         # set text_label bg color (label color)
         if self._text_label is not None:
-            self._text_label.configure(bg=self._apply_appearance_mode(inner_parts_color))
+            self._text_label.configure(bg=self._apply_appearance_mode(inner_parts_color),
+                                      fg=self._apply_appearance_mode(self._text_color))
 
         # set image_label bg color (image bg color)
         if self._image_label is not None:


### PR DESCRIPTION
fixed the display of text on the opposite (when importing a custom theme) button module. That is, when you hover over the button, if the colors are bright, then the text merges with the background, this behavior was added in the `_on_enter` and `_on_leave` functions, respectively. 

- before:
![image](https://user-images.githubusercontent.com/29706062/206478176-004ac5bb-2fe9-47da-b6e2-f17fefa74195.png)
- after:
![image](https://user-images.githubusercontent.com/29706062/206477331-5985ea21-9d85-4314-9eb5-d8897a71310d.png)

