### PR TITLE
Scrollable Frame for CustomTkinter

### DIFF
--- a/customtkinter/__init__.py
+++ b/customtkinter/__init__.py
@@ -33,7 +33,7 @@ from .windows.widgets import CTkSlider
 from .windows.widgets import CTkSwitch
 from .windows.widgets import CTkTabview
 from .windows.widgets import CTkTextbox
-
+from .windows.widgets import CTkScrollableFrame
 # import windows
 from .windows import CTk
 from .windows import CTkToplevel

--- a/customtkinter/windows/widgets/__init__.py
+++ b/customtkinter/windows/widgets/__init__.py
@@ -13,3 +13,4 @@ from .ctk_slider import CTkSlider
 from .ctk_switch import CTkSwitch
 from .ctk_tabview import CTkTabview
 from .ctk_textbox import CTkTextbox
+from .ctk_scrollable_frame import CTkScrollableFrame

--- a/customtkinter/windows/widgets/ctk_scrollable_frame.py
+++ b/customtkinter/windows/widgets/ctk_scrollable_frame.py
@@ -1,0 +1,70 @@
+from typing import Optional, Union, Tuple
+
+import customtkinter
+
+
+class ScrollableFrame(customtkinter.CTkFrame):
+    """
+    A scrollable frame that allows you to add any kind of items (including frames with multiple widgets on it).
+    all you have to do is inherit from this class. Example
+
+    parent_scrollable = customtkinter.ScrollableFrame(parent)
+    item = customtkinter.CTkFrame(master=parent_scrollable.scrollable_frame)
+    """
+
+    def __init__(self, parent, *args, **kwargs):
+        super().__init__(parent, *args, **kwargs)
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_rowconfigure(0, weight=1)
+
+        self.canvas = customtkinter.CTkCanvas(self, highlightthickness=0)
+        self.canvas.grid(row=0, column=0, sticky="nswe")
+        self.canvas.grid_rowconfigure(0, weight=1)
+        self.canvas.grid_columnconfigure(0, weight=1)
+
+        self.update_canvas_color()
+
+        self.scrollbar = customtkinter.CTkScrollbar(self, command=self.canvas.yview)
+        self.scrollbar.grid(row=0, column=1, sticky="nswe")
+
+        self.scrollable_frame = customtkinter.CTkFrame(self.canvas, width=60000, height=50000) #scrollable frame is invisible. assuming it was stretched at max, the scroll upwards bug wont happen
+        self.scrollable_frame.configure(fg_color='transparent')
+
+        self.scrollable_frame.grid_columnconfigure(0, weight=1)
+        self.update_scrollable_frame_color()
+
+        self._frame_id = self.canvas.create_window(0, 0, window=self.scrollable_frame, anchor=customtkinter.NW)
+        self.canvas.configure(yscrollcommand=self.scrollbar.set)
+
+        self.canvas.bind("<Configure>", self.resize_frame)  # increase the items inside the canvas as the canvas grows
+
+        self.scrollable_frame.bind(
+            "<Configure>",
+            lambda e: self.canvas.configure(
+                scrollregion=self.canvas.bbox("all")
+            )
+        )
+        self.canvas.bind('<Enter>', lambda e: self.canvas.bind_all("<MouseWheel>", self._on_mousewheel))
+        self.canvas.bind('<Leave>', lambda e: self.canvas.unbind_all('<MouseWheel>'))
+
+
+    def resize_frame(self, e):
+        self.canvas.itemconfig(self._frame_id, height=None,
+                               width=e.width)  # height = None because otherwise wont scroll
+
+    def _on_mousewheel(self, event):
+        self.canvas.yview_scroll(int(-1 * (event.delta / 120)), "units")
+        # self.canvas.yview_moveto(int(-1 * (event.delta / 120)))
+
+    def update_canvas_color(self):
+        # because for some reason, Ctk canvas do not update automatically
+        if customtkinter.get_appearance_mode() == "Light":
+            self.canvas.configure(bg="#ffffff")
+        if customtkinter.get_appearance_mode() == "Dark":
+            self.canvas.configure(bg="#343638")
+
+    def update_scrollable_frame_color(self):
+        if customtkinter.get_appearance_mode() == "Light":
+            self.scrollable_frame.configure(bg_color="#ffffff")
+        if customtkinter.get_appearance_mode() == "Dark":
+            self.scrollable_frame.configure(bg_color="#343638")

--- a/customtkinter/windows/widgets/ctk_scrollable_frame.py
+++ b/customtkinter/windows/widgets/ctk_scrollable_frame.py
@@ -1,9 +1,12 @@
 from typing import Optional, Union, Tuple
 
-import customtkinter
+from .core_rendering import CTkCanvas
+from .ctk_scrollbar import CTkScrollbar
+from .ctk_frame import CTkFrame
+from .appearance_mode import AppearanceModeTracker
 
 
-class CTkScrollableFrame(customtkinter.CTkFrame):
+class CTkScrollableFrame(CTkFrame):
     """
     A scrollable frame that allows you to add any kind of items (including frames with multiple widgets on it).
     all you have to do is inherit from this class. Example
@@ -17,23 +20,23 @@ class CTkScrollableFrame(customtkinter.CTkFrame):
         self.grid_columnconfigure(0, weight=1)
         self.grid_rowconfigure(0, weight=1)
 
-        self.canvas = customtkinter.CTkCanvas(self, highlightthickness=0)
+        self.canvas = CTkCanvas(self, highlightthickness=0)
         self.canvas.grid(row=0, column=0, sticky="nswe")
         self.canvas.grid_rowconfigure(0, weight=1)
         self.canvas.grid_columnconfigure(0, weight=1)
 
         self.update_canvas_color()
 
-        self.scrollbar = customtkinter.CTkScrollbar(self, command=self.canvas.yview)
+        self.scrollbar = CTkScrollbar(self, command=self.canvas.yview)
         self.scrollbar.grid(row=0, column=1, sticky="nswe")
 
-        self.scrollable_frame = customtkinter.CTkFrame(self.canvas, width=60000, height=50000) #scrollable frame is invisible. assuming it was stretched at max, the scroll upwards bug wont happen
+        self.scrollable_frame = CTkFrame(self.canvas, width=60000, height=50000) #scrollable frame is invisible. assuming it was stretched at max, the scroll upwards bug wont happen
         self.scrollable_frame.configure(fg_color='transparent')
 
         self.scrollable_frame.grid_columnconfigure(0, weight=1)
         self.update_scrollable_frame_color()
 
-        self._frame_id = self.canvas.create_window(0, 0, window=self.scrollable_frame, anchor=customtkinter.NW)
+        self._frame_id = self.canvas.create_window(0, 0, window=self.scrollable_frame,)
         self.canvas.configure(yscrollcommand=self.scrollbar.set)
 
         self.canvas.bind("<Configure>", self.resize_frame)  # increase the items inside the canvas as the canvas grows
@@ -56,15 +59,21 @@ class CTkScrollableFrame(customtkinter.CTkFrame):
         self.canvas.yview_scroll(int(-1 * (event.delta / 120)), "units")
         # self.canvas.yview_moveto(int(-1 * (event.delta / 120)))
 
+    def get_appearance_mode(self) -> str:
+        """ get current state of the appearance mode (light or dark) """
+        if AppearanceModeTracker.appearance_mode == 0:
+            return "Light"
+        elif AppearanceModeTracker.appearance_mode == 1:
+            return "Dark"
     def update_canvas_color(self):
         # because for some reason, Ctk canvas do not update automatically
-        if customtkinter.get_appearance_mode() == "Light":
+        if self.get_appearance_mode() == "Light":
             self.canvas.configure(bg="#ffffff")
-        if customtkinter.get_appearance_mode() == "Dark":
+        if self.get_appearance_mode() == "Dark":
             self.canvas.configure(bg="#343638")
 
     def update_scrollable_frame_color(self):
-        if customtkinter.get_appearance_mode() == "Light":
+        if self.get_appearance_mode() == "Light":
             self.scrollable_frame.configure(bg_color="#ffffff")
-        if customtkinter.get_appearance_mode() == "Dark":
+        if self.get_appearance_mode() == "Dark":
             self.scrollable_frame.configure(bg_color="#343638")

--- a/customtkinter/windows/widgets/ctk_scrollable_frame.py
+++ b/customtkinter/windows/widgets/ctk_scrollable_frame.py
@@ -3,7 +3,7 @@ from typing import Optional, Union, Tuple
 import customtkinter
 
 
-class ScrollableFrame(customtkinter.CTkFrame):
+class CTkScrollableFrame(customtkinter.CTkFrame):
     """
     A scrollable frame that allows you to add any kind of items (including frames with multiple widgets on it).
     all you have to do is inherit from this class. Example


### PR DESCRIPTION
Scrollable frames allow you to put any kind of components inside of a window that allows you to scroll (including frames themselves). 
It is used a lot and isn't implemented in any library so I decided to do it.