### PR TITLE
Added CTkTooltip

### DIFF
--- a/customtkinter/__init__.py
+++ b/customtkinter/__init__.py
@@ -38,6 +38,7 @@ from .windows.widgets import CTkTextbox
 from .windows import CTk
 from .windows import CTkToplevel
 from .windows import CTkInputDialog
+from .windows import CTkTooltip
 
 # import font classes
 from .windows.widgets.font import CTkFont

--- a/customtkinter/windows/__init__.py
+++ b/customtkinter/windows/__init__.py
@@ -1,3 +1,4 @@
 from .ctk_tk import CTk
 from .ctk_toplevel import CTkToplevel
 from .ctk_input_dialog import CTkInputDialog
+from .ctk_tooltip import CTkTooltip

--- a/customtkinter/windows/ctk_tooltip.py
+++ b/customtkinter/windows/ctk_tooltip.py
@@ -17,9 +17,9 @@ class CTkTooltip(CTkToplevel):
                  **kwargs):
         self.wait_time = delay  # milliseconds until tooltip appears
         self.wrap_length = wrap_length  # wrap length of the tooltip text
-        self.master = master
-        self.text = text
-        self.mouse_offset = mouse_offset
+        self.master = master  # parent widget
+        self.text = text  # text to display
+        self.mouse_offset = mouse_offset  # offset from mouse position (x, y)
         self.master.bind("<Enter>", self._schedule, add="+")
         self.master.bind("<Leave>", self._leave, add="+")
         self.master.bind("<ButtonPress>", self._leave, add="+")
@@ -86,6 +86,7 @@ class CTkTooltip(CTkToplevel):
         self.withdraw()
 
     def configure(self, **kwargs):
+        # Change attributes of the tooltip, and redraw if necessary
         require_redraw = False
         if "fg_color" in kwargs:
             self.fg_color = kwargs["fg_color"]

--- a/customtkinter/windows/ctk_tooltip.py
+++ b/customtkinter/windows/ctk_tooltip.py
@@ -1,0 +1,116 @@
+from .widgets.theme.theme_manager import ThemeManager
+from .ctk_toplevel import CTkToplevel
+from .widgets.ctk_label import CTkLabel
+from .widgets.appearance_mode.appearance_mode_tracker import AppearanceModeTracker
+from typing import Union, Tuple
+
+
+class CTkTooltip(CTkToplevel):
+    # Mouse hover tooltips that can be attached to widgets
+    def __init__(self, master,
+                 text: str = 'CTk Tooltip',
+                 delay: int = 500,
+                 wrap_length: int = -1,
+                 bg_color: Union[str, Tuple[str, str]] = "transparent",
+                 fg_color: Union[str, Tuple[str, str]] = "default",
+                 mouse_offset: Tuple[int, int] = (1, 1),
+                 **kwargs):
+        self.wait_time = delay  # milliseconds
+        self.wrap_length = wrap_length
+        self.master = master
+        self.text = text
+        self.mouse_offset = mouse_offset
+        self.master.bind("<Enter>", self._schedule, add="+")
+        self.master.bind("<Leave>", self._leave, add="+")
+        self.master.bind("<ButtonPress>", self._leave, add="+")
+        self._id = None
+        self.kwargs = kwargs
+        self._visible = False
+
+        # determine colors
+        self.fg_color = ThemeManager.theme["CTkFrame"]["top_fg_color"] if fg_color == "default" else fg_color
+        if bg_color == "transparent":
+            if bg_color.startswith('#'):
+                color_list = [int(fg_color[i:i + 2], 16) for i in range(1, len(fg_color), 2)]
+                if not any(color == 255 for color in color_list):
+                    for i in range(len(color_list)):
+                        color_list[i] += 1
+                else:
+                    for i in range(len(color_list)):
+                        color_list[i] -= 1
+
+                self.bg_color = "#" + ''.join(['{:02x}'.format(x) for x in color_list])
+            else:
+                self.__appearance_mode = AppearanceModeTracker.get_mode()
+                if self.__appearance_mode == 0:
+                    self.bg_color = 'gray86' if self.fg_color != 'gray86' else 'gray84'
+                else:
+                    self.bg_color = 'gray17' if self.fg_color != 'gray17' else 'gray15'
+        else:
+            self.bg_color = bg_color
+
+    def _leave(self, event=None):
+        self._unschedule()
+        if self._visible: self.hide()
+        self._visible = False
+
+    def _schedule(self, event=None):
+        self._id = self.master.after(self.wait_time, self.show)
+
+    def _unschedule(self):
+        # Unschedule scheduled popups
+        id = self._id
+        self._id = None
+        if id:
+            self.master.after_cancel(id)
+
+    def show(self, event=None):
+        # Get the position the tooltip needs to appear at
+        super().__init__(self.master, **self.kwargs)
+        self._visible = True
+        x = y = 0
+        x, y, cx, cy = self.master.bbox("insert")
+        # Has to be offset from mouse position, otherwise it will appear and disappear instantly because it left the parent widget
+        x += self.master.winfo_pointerx() + self.mouse_offset[0]
+        y += self.master.winfo_pointery() + self.mouse_offset[1]
+        self.wm_attributes("-toolwindow", True)
+        self.wm_overrideredirect(True)
+        self.wm_geometry(f'+{x}+{y}')
+        self.wm_attributes('-transparentcolor', self.bg_color)
+        super().configure(bg_color=self.bg_color)
+        label = CTkLabel(self, text=self.text, corner_radius=10, bg_color=self.bg_color, fg_color=self.fg_color, width=1, wraplength=self.wrap_length)
+        label.pack()
+
+    def hide(self):
+        self._unschedule()
+        self.withdraw()
+
+    def configure(self, **kwargs):
+        require_redraw = False
+        if "fg_color" in kwargs:
+            self.fg_color = kwargs["fg_color"]
+            require_redraw = True
+            del kwargs["fg_color"]
+        if "bg_color" in kwargs:
+            self.bg_color = kwargs["bg_color"]
+            require_redraw = True
+            del kwargs["bg_color"]
+        if "text" in kwargs:
+            self.text = kwargs["text"]
+            require_redraw = True
+            del kwargs["text"]
+        if "delay" in kwargs:
+            self.wait_time = kwargs["delay"]
+            del kwargs["delay"]
+        if "wrap_length" in kwargs:
+            self.wrap_length = kwargs["wrap_length"]
+            require_redraw = True
+            del kwargs["wrap_length"]
+        if "mouse_offset" in kwargs:
+            self.mouse_offset = kwargs["mouse_offset"]
+            require_redraw = True
+            del kwargs["mouse_offset"]
+        super().configure(**kwargs)
+        if require_redraw:
+            self.hide()
+            self.show()

--- a/customtkinter/windows/ctk_tooltip.py
+++ b/customtkinter/windows/ctk_tooltip.py
@@ -75,6 +75,7 @@ class CTkTooltip(CTkToplevel):
 
     def show(self, event=None):
         # Get the position the tooltip needs to appear at
+        if self._visible: return
         super().__init__(self.master)
         super().withdraw() # hide and reshow window once all code is ran to fix issues due to slower machines (??)
         self._visible = True

--- a/customtkinter/windows/ctk_tooltip.py
+++ b/customtkinter/windows/ctk_tooltip.py
@@ -15,8 +15,8 @@ class CTkTooltip(CTkToplevel):
                  fg_color: Union[str, Tuple[str, str]] = "default",
                  mouse_offset: Tuple[int, int] = (1, 1),
                  **kwargs):
-        self.wait_time = delay  # milliseconds
-        self.wrap_length = wrap_length
+        self.wait_time = delay  # milliseconds until tooltip appears
+        self.wrap_length = wrap_length  # wrap length of the tooltip text
         self.master = master
         self.text = text
         self.mouse_offset = mouse_offset
@@ -66,7 +66,7 @@ class CTkTooltip(CTkToplevel):
 
     def show(self, event=None):
         # Get the position the tooltip needs to appear at
-        super().__init__(self.master, **self.kwargs)
+        super().__init__(self.master)
         self._visible = True
         x = y = 0
         x, y, cx, cy = self.master.bbox("insert")
@@ -78,7 +78,7 @@ class CTkTooltip(CTkToplevel):
         self.wm_geometry(f'+{x}+{y}')
         self.wm_attributes('-transparentcolor', self.bg_color)
         super().configure(bg_color=self.bg_color)
-        label = CTkLabel(self, text=self.text, corner_radius=10, bg_color=self.bg_color, fg_color=self.fg_color, width=1, wraplength=self.wrap_length)
+        label = CTkLabel(self, text=self.text, corner_radius=10, bg_color=self.bg_color, fg_color=self.fg_color, width=1, wraplength=self.wrap_length, **self.kwargs)
         label.pack()
 
     def hide(self):

--- a/customtkinter/windows/ctk_tooltip.py
+++ b/customtkinter/windows/ctk_tooltip.py
@@ -60,11 +60,9 @@ class CTkTooltip(CTkToplevel):
 
     def _leave(self, event=None):
         self._unschedule()
-        print("leave")
         if self._visible: self.hide()
 
     def _schedule(self, event=None):
-        print("schedule")
         self._unschedule()
         self._id = self.master.after(self.wait_time, self.show)
 
@@ -76,7 +74,6 @@ class CTkTooltip(CTkToplevel):
             self.master.after_cancel(id)
 
     def show(self, event=None):
-        print("show")
         # Get the position the tooltip needs to appear at
         super().__init__(self.master)
         super().withdraw() # hide and reshow window once all code is ran to fix issues due to slower machines (??)
@@ -105,7 +102,6 @@ class CTkTooltip(CTkToplevel):
         super().deiconify()
 
     def hide(self):
-        print("hide")
         self._unschedule()
         self.withdraw()
         self._visible = False

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -26,6 +26,7 @@ progressbar_1.pack(pady=10, padx=10)
 
 button_1 = customtkinter.CTkButton(master=frame_1, command=button_callback)
 button_1.pack(pady=10, padx=10)
+tooltip_1 = customtkinter.CTkTooltip(master=button_1)
 
 slider_1 = customtkinter.CTkSlider(master=frame_1, command=slider_callback, from_=0, to=1)
 slider_1.pack(pady=10, padx=10)


### PR DESCRIPTION
I have added tooltips which appear when your mouse hovers over a widget. These can be very useful for describing the purposes of widgets such as buttons, without using the widget's text to describe it. This is possible using Toplevels and transparent colors to give the tooltip rounded edges.

![image](https://user-images.githubusercontent.com/79729769/216791350-c87c92e4-c861-41cf-ba79-ee71ed870574.png)


Here is a more practical example, where tooltips are used to indicate the usage of a button represented only with an icon:
![image](https://user-images.githubusercontent.com/79729769/213933911-5da900eb-6bfb-4a48-a9be-1ae65706574a.png)
Allowing for a clean and modern user interface.

Please consider adding this as I think many people would find it useful
