### PR TITLE
fix(ctk_toplevel): removed excess icon setting

### DIFF
--- a/customtkinter/windows/ctk_toplevel.py
+++ b/customtkinter/windows/ctk_toplevel.py
@@ -38,14 +38,6 @@ class CTkToplevel(tkinter.Toplevel, CTkAppearanceModeBaseClass, CTkScalingBaseCl
         CTkScalingBaseClass.__init__(self, scaling_type="window")
         check_kwargs_empty(kwargs, raise_error=True)
 
-        try:
-            # Set Windows titlebar icon
-            if sys.platform.startswith("win"):
-                customtkinter_directory = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-                self.after(200, lambda: self.iconbitmap(os.path.join(customtkinter_directory, "assets", "icons", "CustomTkinter_icon_Windows.ico")))
-        except Exception:
-            pass
-
         self._current_width = 200  # initial window size, always without scaling
         self._current_height = 200
         self._min_width: int = 0


### PR DESCRIPTION
Default icon is always automatically set in `__init__ ` method of Toplevel **TWICE** after 200 msec after creation. 
It is called correctly in the end of `__init__` method when you call `self._windows_set_titlebar_icon()` 200 msec after creating the Toplevel window and it doesn't change icon if user already set his own one. 
But for the first time you call it one more time without any checks in the beginning of the `__init__ ` method. Please delete that excess call in the next update.