### PR TITLE
theme manager: fix path to assets for PyInstaller on POSIX systems

### DIFF
--- a/customtkinter/windows/widgets/theme/theme_manager.py
+++ b/customtkinter/windows/widgets/theme/theme_manager.py
@@ -15,7 +15,8 @@ class ThemeManager:
         script_directory = os.path.dirname(os.path.abspath(__file__))
 
         if theme_name_or_path in cls._built_in_themes:
-            with open(os.path.join(script_directory, "../../../assets", "themes", f"{theme_name_or_path}.json"), "r") as f:
+            customtkinter_directory = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+            with open(os.path.join(customtkinter_directory, "assets", "themes", f"{theme_name_or_path}.json"), "r") as f:
                 cls.theme = json.load(f)
         else:
             with open(theme_name_or_path, "r") as f:


### PR DESCRIPTION
Avoid referencing the assets directory as relative to the `customtkinter/windows/widgets/theme`, which does not exist in PyInstaller-frozen applications due to python modules being collected into executable-embedded archive.

Relative referencing from non-existant directories, such as `customtkinter/windows/widgets/theme/../../../assets` does not work on POSIX systems (Linux and macOS) and results in file-not-found errors even though the actual target directory (`customtkinter/assets`) and its contents exist.

Instead, resolve the top-level `customtkinter` directoy and its assets sub-directory via the pattern that is found in [other parts of the code](https://github.com/TomSchimansky/CustomTkinter/blob/6e9258a444a400dc298111f1b062c9023e260fa9/customtkinter/windows/widgets/font/__init__.py#L14) (i.e., use `os.dirname` to jump to parent directories from `__file__` location).