### PR TITLE
fixed cancel button in CtkInputDialog

### DIFF
--- a/customtkinter/windows/ctk_input_dialog.py
+++ b/customtkinter/windows/ctk_input_dialog.py
@@ -86,7 +86,7 @@ class CTkInputDialog(CTkToplevel):
                                         hover_color=self._button_hover_color,
                                         text_color=self._button_text_color,
                                         text='Cancel',
-                                        command=self._ok_event)
+                                        command=self._cancel_event)
         self._cancel_button.grid(row=2, column=1, columnspan=1, padx=(10, 20), pady=(0, 20), sticky="ew")
 
         self.after(150, lambda: self._entry.focus())  # set focus to entry with slight delay, otherwise it won't work


### PR DESCRIPTION
Both ok and cancel buttons were associated with the ok_event. 
After the fix, the ok button is still associated with such an event, while the cancel button is now associated with the cancel_event. 