### PR TITLE
Fix Frame fg_color inside ScrollableFrame

### DIFF
--- a/customtkinter/windows/widgets/ctk_frame.py
+++ b/customtkinter/windows/widgets/ctk_frame.py
@@ -4,6 +4,7 @@ from .core_rendering import CTkCanvas
 from .theme import ThemeManager
 from .core_rendering import DrawEngine
 from .core_widget_classes import CTkBaseClass
+import customtkinter.windows.widgets as widgets
 
 
 class CTkFrame(CTkBaseClass):
@@ -44,6 +45,8 @@ class CTkFrame(CTkBaseClass):
                     self._fg_color = ThemeManager.theme["CTkFrame"]["fg_color"]
             else:
                 self._fg_color = ThemeManager.theme["CTkFrame"]["fg_color"]
+            if isinstance(self.master, widgets.ctk_scrollable_frame.CTkScrollableFrame):
+                self._fg_color = ThemeManager.theme["CTkFrame"]["top_fg_color"]
         else:
             self._fg_color = self._check_color_type(fg_color, transparency=True)
 


### PR DESCRIPTION
Frames inside ScrollableFrames did not get a new top level fg_color and remained the same color as the parent. Implemented a fix by checking if the parent of a Frame is a ScrollableFrame and changing the fg_color to be like any Frame inside another Frame.

See here for the before:
![beforectk](https://user-images.githubusercontent.com/38565928/222281605-8a24d73f-8988-41a1-a527-21b83307ffe5.PNG)

And After:
![afterctk](https://user-images.githubusercontent.com/38565928/222281668-37c9bc2a-39bd-4b5a-a333-c8363c1be9a8.PNG)
