### PR TITLE
Scaling error after deleting dropdown

### DIFF
--- a/customtkinter/windows/widgets/core_widget_classes/dropdown_menu.py
+++ b/customtkinter/windows/widgets/core_widget_classes/dropdown_menu.py
@@ -50,6 +50,7 @@ class DropdownMenu(tkinter.Menu, CTkAppearanceModeBaseClass, CTkScalingBaseClass
         # call destroy methods of super classes
         tkinter.Menu.destroy(self)
         CTkAppearanceModeBaseClass.destroy(self)
+        CTkScalingBaseClass.destroy(self)
 
     def _update_font(self):
         """ pass font to tkinter widgets with applied font scaling """


### PR DESCRIPTION
Fixes #1304

Added CTkScalingBaseClass.destroy(self) to line #53 of dropdown_menu.py

"If customtkinter.set_widget_scaling(new_scaling_float) is called after deleting a CTkOptionMenu or a CTkComboBox object, it throws a _tkinter.TclError: invalid command name"