### PR TITLE
Restore settings for label relief and borderwidth

### DIFF
--- a/customtkinter/windows/widgets/ctk_label.py
+++ b/customtkinter/windows/widgets/ctk_label.py
@@ -17,8 +17,8 @@ class CTkLabel(CTkBaseClass):
     """
 
     # attributes that are passed to and managed by the tkinter entry only:
-    _valid_tk_label_attributes = {"cursor", "justify", "padx", "pady",
-                                  "textvariable", "state", "takefocus", "underline"}
+    _valid_tk_label_attributes = {"cursor", "justify", "padx", "pady", "relief", "borderwidth",
+                                  "bd", "textvariable", "state", "takefocus", "underline"}
 
     def __init__(self,
                  master: any,
@@ -79,7 +79,6 @@ class CTkLabel(CTkBaseClass):
                                     highlightthickness=0,
                                     padx=0,
                                     pady=0,
-                                    borderwidth=0,
                                     anchor=self._anchor,
                                     compound=self._compound,
                                     wraplength=self._apply_widget_scaling(self._wraplength),

--- a/test/manual_integration_tests/test_relief.py
+++ b/test/manual_integration_tests/test_relief.py
@@ -1,0 +1,20 @@
+import tkinter as tk
+import customtkinter as ctk
+
+window = ctk.CTk()
+
+ctk.CTkLabel(window, text='Flat', padx=10).pack()
+ctk.CTkLabel(window, text='Sunken', relief='sunken', borderwidth=5, padx=10).pack()
+ctk.CTkLabel(window, text='Raised', relief='raised', borderwidth=5, padx=10).pack()
+ctk.CTkLabel(window, text='Groove', relief='groove', borderwidth=5, padx=10).pack()
+ctk.CTkLabel(window, text='Ridge', relief='ridge', borderwidth=5, padx=10).pack()
+
+ctk.CTkLabel(window, text="bd", relief='raised', bd=5, padx=10).pack()
+ctk.CTkLabel(window, text="both", relief='raised', bd=5, borderwidth=1, padx=10).pack()
+ctk.CTkLabel(window, text="both flipped", relief='raised', borderwidth=1, bd=5, padx=10).pack()
+
+configure = ctk.CTkLabel(window, text="configured", relief='raised', bd=5, padx=10)
+configure.configure(borderwidth=1)
+configure.pack()
+
+window.mainloop()


### PR DESCRIPTION
Restores relief and borderwidth/bd settings to CTkLabel.  The are all passed directly to and handled by the tkinter.Label object.

Fixes #1466 