### PR TITLE
Event Generation on _canvas Based Widgets and Added Invalidate Command

### DIFF
--- a/customtkinter/windows/ctk_tk.py
+++ b/customtkinter/windows/ctk_tk.py
@@ -107,13 +107,13 @@ class CTk(tkinter.Tk, CTkAppearanceModeBaseClass, CTkScalingBaseClass):
     def _set_scaling(self, new_widget_scaling, new_window_scaling):
         super()._set_scaling(new_widget_scaling, new_window_scaling)
 
-        # Force new dimensions on window by using min, max, and geometry. Without min, max it won't work.
+        # Force new dimensions on window by using abs_min, max, and geometry. Without abs_min, max it won't work.
         super().minsize(self._apply_window_scaling(self._current_width), self._apply_window_scaling(self._current_height))
         super().maxsize(self._apply_window_scaling(self._current_width), self._apply_window_scaling(self._current_height))
 
         super().geometry(f"{self._apply_window_scaling(self._current_width)}x{self._apply_window_scaling(self._current_height)}")
 
-        # set new scaled min and max with delay (delay prevents weird bug where window dimensions snap to unscaled dimensions when mouse releases window)
+        # set new scaled abs_min and max with delay (delay prevents weird bug where window dimensions snap to unscaled dimensions when mouse releases window)
         self.after(1000, self._set_scaled_min_max)  # Why 1000ms delay? Experience! (Everything tested on Windows 11)
 
     def block_update_dimensions_event(self):
@@ -196,7 +196,7 @@ class CTk(tkinter.Tk, CTkAppearanceModeBaseClass, CTkScalingBaseClass):
             # update width and height attributes
             width, height, x, y = self._parse_geometry_string(geometry_string)
             if width is not None and height is not None:
-                self._current_width = max(self._min_width, min(width, self._max_width))  # bound value between min and max
+                self._current_width = max(self._min_width, min(width, self._max_width))  # bound value between abs_min and max
                 self._current_height = max(self._min_height, min(height, self._max_height))
         else:
             return self._reverse_geometry_scaling(super().geometry())

--- a/customtkinter/windows/ctk_toplevel.py
+++ b/customtkinter/windows/ctk_toplevel.py
@@ -109,13 +109,13 @@ class CTkToplevel(tkinter.Toplevel, CTkAppearanceModeBaseClass, CTkScalingBaseCl
     def _set_scaling(self, new_widget_scaling, new_window_scaling):
         super()._set_scaling(new_widget_scaling, new_window_scaling)
 
-        # Force new dimensions on window by using min, max, and geometry. Without min, max it won't work.
+        # Force new dimensions on window by using abs_min, max, and geometry. Without abs_min, max it won't work.
         super().minsize(self._apply_window_scaling(self._current_width), self._apply_window_scaling(self._current_height))
         super().maxsize(self._apply_window_scaling(self._current_width), self._apply_window_scaling(self._current_height))
 
         super().geometry(f"{self._apply_window_scaling(self._current_width)}x{self._apply_window_scaling(self._current_height)}")
 
-        # set new scaled min and max with delay (delay prevents weird bug where window dimensions snap to unscaled dimensions when mouse releases window)
+        # set new scaled abs_min and max with delay (delay prevents weird bug where window dimensions snap to unscaled dimensions when mouse releases window)
         self.after(1000, self._set_scaled_min_max)  # Why 1000ms delay? Experience! (Everything tested on Windows 11)
 
     def block_update_dimensions_event(self):
@@ -137,7 +137,7 @@ class CTkToplevel(tkinter.Toplevel, CTkAppearanceModeBaseClass, CTkScalingBaseCl
             # update width and height attributes
             width, height, x, y = self._parse_geometry_string(geometry_string)
             if width is not None and height is not None:
-                self._current_width = max(self._min_width, min(width, self._max_width))  # bound value between min and max
+                self._current_width = max(self._min_width, min(width, self._max_width))  # bound value between abs_min and max
                 self._current_height = max(self._min_height, min(height, self._max_height))
         else:
             return self._reverse_geometry_scaling(super().geometry())

--- a/customtkinter/windows/widgets/ctk_entry.py
+++ b/customtkinter/windows/widgets/ctk_entry.py
@@ -19,7 +19,7 @@ class CTkEntry(CTkBaseClass):
 
     # attributes that are passed to and managed by the tkinter entry only:
     _valid_tk_entry_attributes = {"exportselection", "insertborderwidth", "insertofftime",
-                                  "insertontime", "insertwidth", "justify", "selectborderwidth",
+                                  "insertontime", "insertwidth", "invalidcommand", "justify", "selectborderwidth",
                                   "show", "takefocus", "validate", "validatecommand", "xscrollcommand"}
 
     def __init__(self,

--- a/customtkinter/windows/widgets/ctk_frame.py
+++ b/customtkinter/windows/widgets/ctk_frame.py
@@ -194,3 +194,7 @@ class CTkFrame(CTkBaseClass):
             raise ValueError("'funcid' argument can only be None, because there is a bug in" +
                              " tkinter and its not clear whether the internal callbacks will be unbinded or not")
         self._canvas.unbind(sequence, None)
+
+    def event_generate(self, sequence, **kw):
+        """ called on the tkinter.Canvas """
+        self._canvas.event_generate(sequence, **kw)

--- a/customtkinter/windows/widgets/ctk_label.py
+++ b/customtkinter/windows/widgets/ctk_label.py
@@ -281,6 +281,10 @@ class CTkLabel(CTkBaseClass):
         self._canvas.unbind(sequence, None)
         self._label.unbind(sequence, None)
 
+    def event_generate(self, sequence, **kw):
+        """ called on the tkinter.Canvas """
+        self._canvas.event_generate(sequence, **kw)
+
     def focus(self):
         return self._label.focus()
 

--- a/customtkinter/windows/widgets/ctk_progressbar.py
+++ b/customtkinter/windows/widgets/ctk_progressbar.py
@@ -302,6 +302,10 @@ class CTkProgressBar(CTkBaseClass):
                              " tkinter and its not clear whether the internal callbacks will be unbinded or not")
         self._canvas.unbind(sequence, None)
 
+    def event_generate(self, sequence, **kw):
+        """ called on the tkinter.Canvas """
+        self._canvas.event_generate(sequence, **kw)
+
     def focus(self):
         return self._canvas.focus()
 

--- a/customtkinter/windows/widgets/ctk_scrollbar.py
+++ b/customtkinter/windows/widgets/ctk_scrollbar.py
@@ -271,6 +271,10 @@ class CTkScrollbar(CTkBaseClass):
         self._canvas.unbind(sequence, None)  # unbind all callbacks for sequence
         self._create_bindings(sequence=sequence)  # restore internal callbacks for sequence
 
+    def event_generate(self, sequence, **kw):
+        """ called on the tkinter.Canvas """
+        self._canvas.event_generate(sequence, **kw)
+
     def focus(self):
         return self._canvas.focus()
 

--- a/customtkinter/windows/widgets/ctk_slider.py
+++ b/customtkinter/windows/widgets/ctk_slider.py
@@ -387,6 +387,10 @@ class CTkSlider(CTkBaseClass):
         self._canvas.unbind(sequence, None)
         self._create_bindings(sequence=sequence)  # restore internal callbacks for sequence
 
+    def event_generate(self, sequence, **kw):
+        """ called on the tkinter.Canvas """
+        self._canvas.event_generate(sequence, **kw)
+
     def focus(self):
         return self._canvas.focus()
 


### PR DESCRIPTION
Put the invalidate command back into acceptable pass variables and works on
entry fields. This allows for tkinter style input validation to take place. Before, only the validation parameters and validation function could be added. Now, if the validation function returns false, the invalidate command provided can run. (Tested on entry)

Override even_generate on widgets that solely use _canvas hidden widget so that custom events work again. See #1524 for details. (Tested on combobox and button)