### PR TITLE
Reset Minsize

### DIFF
--- a/customtkinter/windows/widgets/ctk_button.py
+++ b/customtkinter/windows/widgets/ctk_button.py
@@ -314,7 +314,7 @@ class CTkButton(CTkBaseClass):
             if self._image_label is not None and self._text_label is not None:
                 self.grid_columnconfigure(2, weight=0, minsize=self._apply_widget_scaling(self._image_label_spacing))
             else:
-                self.grid_columnconfigure(2, weight=0)
+                self.grid_columnconfigure(2, weight=0, minsize=0)
 
             self.grid_rowconfigure((1, 3), weight=0)
             self.grid_columnconfigure((1, 3), weight=1)
@@ -323,7 +323,7 @@ class CTkButton(CTkBaseClass):
             if self._image_label is not None and self._text_label is not None:
                 self.grid_rowconfigure(2, weight=0, minsize=self._apply_widget_scaling(self._image_label_spacing))
             else:
-                self.grid_rowconfigure(2, weight=0)
+                self.grid_rowconfigure(2, weight=0, minsize=0)
 
             self.grid_columnconfigure((1, 3), weight=0)
             self.grid_rowconfigure((1, 3), weight=1)


### PR DESCRIPTION
Fixed issue #1899 by resetting the minsize. When text is given, the grid is told to adjust the minsize to fit text in. However, when the text is removed, minsize is not reset, and therefore creates a little bit of extra space due to the oversized column. My solution fixes the text being added and removed, **as well as** the image being added and removed.