### PR TITLE
Update ctk_button.py

### DIFF
--- a/customtkinter/windows/widgets/ctk_button.py
+++ b/customtkinter/windows/widgets/ctk_button.py
@@ -546,7 +546,7 @@ class CTkButton(CTkBaseClass):
         if self._state != tkinter.DISABLED:
 
             # click animation: change color with .on_leave() and back to normal after 100ms with click_animation()
-            self._on_leave()
+            self._on_leave(None)
             self._click_animation_running = True
             self.after(100, self._click_animation)
 


### PR DESCRIPTION
Little Update for the _clicked method.
self._on_leave gets None as an argument.

Reason:
By overwriting the _on_leave method, the code still works when the method does not have event=None

There were issues with a own method like this:

class Own_Button(ctk.CTkButton):
    def _on_leave(event):
        super()._on_leave(event)
        # do some stuff


