### PR TITLE
Removed code that was causing transparency bug in windows 10.

### DIFF
--- a/customtkinter/windows/widgets/scaling/scaling_tracker.py
+++ b/customtkinter/windows/widgets/scaling/scaling_tracker.py
@@ -183,10 +183,8 @@ class ScalingTracker:
                     if sys.platform.startswith("win"):
                         window.attributes("-alpha", 0.15)
 
-                    window.block_update_dimensions_event()
                     cls.update_scaling_callbacks_for_window(window)
-                    window.unblock_update_dimensions_event()
-
+                    
                     if sys.platform.startswith("win"):
                         window.attributes("-alpha", 1)
 


### PR DESCRIPTION
This PR relates to https://github.com/TomSchimansky/CustomTkinter/issues/2013.

There was a transparency bug in some versions of Windows 10 and Windows 11, which could be traced to the lines of code this PR removes. I've tested this in Windows 10 and saw no decrease in functionality, nor did I see any bugs. 

List of tested OS/Versions:
Microsoft Windows 10 Home - 10.0.19045 Build 19045
Ubuntu - 22.04.1

If more OS's are requested for testing, please let me know and I can conduct that testing.

