### PR TITLE
Add missing packaging dependency to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,4 +35,5 @@ packages =
 install_requires =
     darkdetect
     typing_extensions; python_version<="3.7"
+    packaging
 include_package_data = True


### PR DESCRIPTION
Fixes #2036 due to [packaging](https://pypi.org/project/packaging/) not being specified as a dependency in setup.cfg which appeared to be missing from 4b6e2ad2db2d5b3afbadb33d1794991e836f3381. This issue is currently present in v5.2.1 on PyPI.