### PR TITLE
Fixed an exception when destroying an entry and updating the text variable

### DIFF
--- a/customtkinter/windows/widgets/ctk_entry.py
+++ b/customtkinter/windows/widgets/ctk_entry.py
@@ -148,6 +148,10 @@ class CTkEntry(CTkBaseClass):
         if isinstance(self._font, CTkFont):
             self._font.remove_size_configure_callback(self._update_font)
 
+        if self._textvariable_callback_name:
+            self._textvariable.trace_remove("write", self._textvariable_callback_name)
+            self._textvariable_callback_name = ""
+
         super().destroy()
 
     def _draw(self, no_color_updates=False):


### PR DESCRIPTION
This fixes an exception that occurs after destroying a CtkEntry with a text variable and then updating that text variable.

`trace_add` is called when the entry is created, but `trace_remove` was never called.

The exception was
`_tkinter.TclError: invalid command name`