### PR TITLE
Justify text of a button

### DIFF
--- a/customtkinter/windows/widgets/ctk_button.py
+++ b/customtkinter/windows/widgets/ctk_button.py
@@ -1,13 +1,12 @@
-import tkinter
 import sys
-from typing import Union, Tuple, Callable, Optional
+import tkinter
+from typing import Callable, Optional, Tuple, Union
 
-from .core_rendering import CTkCanvas
-from .theme import ThemeManager
-from .core_rendering import DrawEngine
+from .core_rendering import CTkCanvas, DrawEngine
 from .core_widget_classes import CTkBaseClass
 from .font import CTkFont
 from .image import CTkImage
+from .theme import ThemeManager
 
 
 class CTkButton(CTkBaseClass):
@@ -18,62 +17,101 @@ class CTkButton(CTkBaseClass):
 
     _image_label_spacing: int = 6
 
-    def __init__(self,
-                 master: any,
-                 width: int = 140,
-                 height: int = 28,
-                 corner_radius: Optional[int] = None,
-                 border_width: Optional[int] = None,
-                 border_spacing: int = 2,
-
-                 bg_color: Union[str, Tuple[str, str]] = "transparent",
-                 fg_color: Optional[Union[str, Tuple[str, str]]] = None,
-                 hover_color: Optional[Union[str, Tuple[str, str]]] = None,
-                 border_color: Optional[Union[str, Tuple[str, str]]] = None,
-                 text_color: Optional[Union[str, Tuple[str, str]]] = None,
-                 text_color_disabled: Optional[Union[str, Tuple[str, str]]] = None,
-
-                 background_corner_colors: Union[Tuple[Union[str, Tuple[str, str]]], None] = None,
-                 round_width_to_even_numbers: bool = True,
-                 round_height_to_even_numbers: bool = True,
-
-                 text: str = "CTkButton",
-                 font: Optional[Union[tuple, CTkFont]] = None,
-                 textvariable: Union[tkinter.Variable, None] = None,
-                 image: Union[CTkImage, "ImageTk.PhotoImage", None] = None,
-                 state: str = "normal",
-                 hover: bool = True,
-                 command: Union[Callable[[], None], None] = None,
-                 compound: str = "left",
-                 anchor: str = "center",
-                 **kwargs):
-
+    def __init__(
+        self,
+        master: any,
+        width: int = 140,
+        height: int = 28,
+        corner_radius: Optional[int] = None,
+        border_width: Optional[int] = None,
+        border_spacing: int = 2,
+        bg_color: Union[str, Tuple[str, str]] = "transparent",
+        fg_color: Optional[Union[str, Tuple[str, str]]] = None,
+        hover_color: Optional[Union[str, Tuple[str, str]]] = None,
+        border_color: Optional[Union[str, Tuple[str, str]]] = None,
+        text_color: Optional[Union[str, Tuple[str, str]]] = None,
+        text_color_disabled: Optional[Union[str, Tuple[str, str]]] = None,
+        background_corner_colors: Union[
+            Tuple[Union[str, Tuple[str, str]]], None
+        ] = None,
+        round_width_to_even_numbers: bool = True,
+        round_height_to_even_numbers: bool = True,
+        text: str = "CTkButton",
+        font: Optional[Union[tuple, CTkFont]] = None,
+        textvariable: Union[tkinter.Variable, None] = None,
+        image: Union[CTkImage, "ImageTk.PhotoImage", None] = None,
+        state: str = "normal",
+        hover: bool = True,
+        command: Union[Callable[[], None], None] = None,
+        compound: str = "left",
+        anchor: str = "center",
+        text_anchor: str = "center",
+        **kwargs
+    ):
         # transfer basic functionality (bg_color, size, appearance_mode, scaling) to CTkBaseClass
-        super().__init__(master=master, bg_color=bg_color, width=width, height=height, **kwargs)
+        super().__init__(
+            master=master, bg_color=bg_color, width=width, height=height, **kwargs
+        )
 
         # shape
-        self._corner_radius: int = ThemeManager.theme["CTkButton"]["corner_radius"] if corner_radius is None else corner_radius
+        self._corner_radius: int = (
+            ThemeManager.theme["CTkButton"]["corner_radius"]
+            if corner_radius is None
+            else corner_radius
+        )
         self._corner_radius = min(self._corner_radius, round(self._current_height / 2))
-        self._border_width: int = ThemeManager.theme["CTkButton"]["border_width"] if border_width is None else border_width
+        self._border_width: int = (
+            ThemeManager.theme["CTkButton"]["border_width"]
+            if border_width is None
+            else border_width
+        )
         self._border_spacing: int = border_spacing
 
         # color
-        self._fg_color: Union[str, Tuple[str, str]] = ThemeManager.theme["CTkButton"]["fg_color"] if fg_color is None else self._check_color_type(fg_color, transparency=True)
-        self._hover_color: Union[str, Tuple[str, str]] = ThemeManager.theme["CTkButton"]["hover_color"] if hover_color is None else self._check_color_type(hover_color)
-        self._border_color: Union[str, Tuple[str, str]] = ThemeManager.theme["CTkButton"]["border_color"] if border_color is None else self._check_color_type(border_color)
-        self._text_color: Union[str, Tuple[str, str]] = ThemeManager.theme["CTkButton"]["text_color"] if text_color is None else self._check_color_type(text_color)
-        self._text_color_disabled: Union[str, Tuple[str, str]] = ThemeManager.theme["CTkButton"]["text_color_disabled"] if text_color_disabled is None else self._check_color_type(text_color_disabled)
+        self._fg_color: Union[str, Tuple[str, str]] = (
+            ThemeManager.theme["CTkButton"]["fg_color"]
+            if fg_color is None
+            else self._check_color_type(fg_color, transparency=True)
+        )
+        self._hover_color: Union[str, Tuple[str, str]] = (
+            ThemeManager.theme["CTkButton"]["hover_color"]
+            if hover_color is None
+            else self._check_color_type(hover_color)
+        )
+        self._border_color: Union[str, Tuple[str, str]] = (
+            ThemeManager.theme["CTkButton"]["border_color"]
+            if border_color is None
+            else self._check_color_type(border_color)
+        )
+        self._text_color: Union[str, Tuple[str, str]] = (
+            ThemeManager.theme["CTkButton"]["text_color"]
+            if text_color is None
+            else self._check_color_type(text_color)
+        )
+        self._text_color_disabled: Union[str, Tuple[str, str]] = (
+            ThemeManager.theme["CTkButton"]["text_color_disabled"]
+            if text_color_disabled is None
+            else self._check_color_type(text_color_disabled)
+        )
 
         # rendering options
-        self._background_corner_colors: Union[Tuple[Union[str, Tuple[str, str]]], None] = background_corner_colors  # rendering options for DrawEngine
-        self._round_width_to_even_numbers: bool = round_width_to_even_numbers  # rendering options for DrawEngine
-        self._round_height_to_even_numbers: bool = round_height_to_even_numbers  # rendering options for DrawEngine
+        self._background_corner_colors: Union[
+            Tuple[Union[str, Tuple[str, str]]], None
+        ] = background_corner_colors  # rendering options for DrawEngine
+        self._round_width_to_even_numbers: bool = (
+            round_width_to_even_numbers  # rendering options for DrawEngine
+        )
+        self._round_height_to_even_numbers: bool = (
+            round_height_to_even_numbers  # rendering options for DrawEngine
+        )
 
         # text, font
         self._text = text
         self._text_label: Union[tkinter.Label, None] = None
         self._textvariable: tkinter.Variable = textvariable
-        self._font: Union[tuple, CTkFont] = CTkFont() if font is None else self._check_font_type(font)
+        self._font: Union[tuple, CTkFont] = (
+            CTkFont() if font is None else self._check_font_type(font)
+        )
         if isinstance(self._font, CTkFont):
             self._font.add_size_configure_callback(self._update_font)
 
@@ -89,16 +127,21 @@ class CTkButton(CTkBaseClass):
         self._command: Callable = command
         self._compound: str = compound
         self._anchor: str = anchor
+        self._text_anchor: str = text_anchor
         self._click_animation_running: bool = False
 
         # canvas and draw engine
-        self._canvas = CTkCanvas(master=self,
-                                 highlightthickness=0,
-                                 width=self._apply_widget_scaling(self._desired_width),
-                                 height=self._apply_widget_scaling(self._desired_height))
+        self._canvas = CTkCanvas(
+            master=self,
+            highlightthickness=0,
+            width=self._apply_widget_scaling(self._desired_width),
+            height=self._apply_widget_scaling(self._desired_height),
+        )
         self._canvas.grid(row=0, column=0, rowspan=5, columnspan=5, sticky="nsew")
         self._draw_engine = DrawEngine(self._canvas)
-        self._draw_engine.set_round_to_even_numbers(self._round_width_to_even_numbers, self._round_height_to_even_numbers)  # rendering options
+        self._draw_engine.set_round_to_even_numbers(
+            self._round_width_to_even_numbers, self._round_height_to_even_numbers
+        )  # rendering options
 
         # configure cursor and initial draw
         self._create_bindings()
@@ -106,7 +149,7 @@ class CTkButton(CTkBaseClass):
         self._draw()
 
     def _create_bindings(self, sequence: Optional[str] = None):
-        """ set necessary bindings for functionality of widget, will overwrite other bindings """
+        """set necessary bindings for functionality of widget, will overwrite other bindings"""
 
         if sequence is None or sequence == "<Enter>":
             self._canvas.bind("<Enter>", self._on_enter)
@@ -142,8 +185,10 @@ class CTkButton(CTkBaseClass):
 
         self._update_image()
 
-        self._canvas.configure(width=self._apply_widget_scaling(self._desired_width),
-                               height=self._apply_widget_scaling(self._desired_height))
+        self._canvas.configure(
+            width=self._apply_widget_scaling(self._desired_width),
+            height=self._apply_widget_scaling(self._desired_height),
+        )
         self._draw(no_color_updates=True)
 
     def _set_appearance_mode(self, mode_string):
@@ -153,12 +198,14 @@ class CTkButton(CTkBaseClass):
     def _set_dimensions(self, width: int = None, height: int = None):
         super()._set_dimensions(width, height)
 
-        self._canvas.configure(width=self._apply_widget_scaling(self._desired_width),
-                               height=self._apply_widget_scaling(self._desired_height))
+        self._canvas.configure(
+            width=self._apply_widget_scaling(self._desired_width),
+            height=self._apply_widget_scaling(self._desired_height),
+        )
         self._draw()
 
     def _update_font(self):
-        """ pass font to tkinter widgets with applied font scaling and update grid with workaround """
+        """pass font to tkinter widgets with applied font scaling and update grid with workaround"""
         if self._text_label is not None:
             self._text_label.configure(font=self._apply_font_scaling(self._font))
 
@@ -170,8 +217,11 @@ class CTkButton(CTkBaseClass):
     def _update_image(self):
         if self._image_label is not None:
             if isinstance(self._image, CTkImage):
-                self._image_label.configure(image=self._image.create_scaled_photo_image(self._get_widget_scaling(),
-                                                                                        self._get_appearance_mode()))
+                self._image_label.configure(
+                    image=self._image.create_scaled_photo_image(
+                        self._get_widget_scaling(), self._get_appearance_mode()
+                    )
+                )
             elif self._image is not None:
                 self._image_label.configure(image=self._image)
 
@@ -184,50 +234,73 @@ class CTkButton(CTkBaseClass):
         super()._draw(no_color_updates)
 
         if self._background_corner_colors is not None:
-            self._draw_engine.draw_background_corners(self._apply_widget_scaling(self._current_width),
-                                                      self._apply_widget_scaling(self._current_height))
-            self._canvas.itemconfig("background_corner_top_left", fill=self._apply_appearance_mode(self._background_corner_colors[0]))
-            self._canvas.itemconfig("background_corner_top_right", fill=self._apply_appearance_mode(self._background_corner_colors[1]))
-            self._canvas.itemconfig("background_corner_bottom_right", fill=self._apply_appearance_mode(self._background_corner_colors[2]))
-            self._canvas.itemconfig("background_corner_bottom_left", fill=self._apply_appearance_mode(self._background_corner_colors[3]))
+            self._draw_engine.draw_background_corners(
+                self._apply_widget_scaling(self._current_width),
+                self._apply_widget_scaling(self._current_height),
+            )
+            self._canvas.itemconfig(
+                "background_corner_top_left",
+                fill=self._apply_appearance_mode(self._background_corner_colors[0]),
+            )
+            self._canvas.itemconfig(
+                "background_corner_top_right",
+                fill=self._apply_appearance_mode(self._background_corner_colors[1]),
+            )
+            self._canvas.itemconfig(
+                "background_corner_bottom_right",
+                fill=self._apply_appearance_mode(self._background_corner_colors[2]),
+            )
+            self._canvas.itemconfig(
+                "background_corner_bottom_left",
+                fill=self._apply_appearance_mode(self._background_corner_colors[3]),
+            )
         else:
             self._canvas.delete("background_parts")
 
-        requires_recoloring = self._draw_engine.draw_rounded_rect_with_border(self._apply_widget_scaling(self._current_width),
-                                                                              self._apply_widget_scaling(self._current_height),
-                                                                              self._apply_widget_scaling(self._corner_radius),
-                                                                              self._apply_widget_scaling(self._border_width))
+        requires_recoloring = self._draw_engine.draw_rounded_rect_with_border(
+            self._apply_widget_scaling(self._current_width),
+            self._apply_widget_scaling(self._current_height),
+            self._apply_widget_scaling(self._corner_radius),
+            self._apply_widget_scaling(self._border_width),
+        )
 
         if no_color_updates is False or requires_recoloring:
-
             self._canvas.configure(bg=self._apply_appearance_mode(self._bg_color))
 
             # set color for the button border parts (outline)
-            self._canvas.itemconfig("border_parts",
-                                    outline=self._apply_appearance_mode(self._border_color),
-                                    fill=self._apply_appearance_mode(self._border_color))
+            self._canvas.itemconfig(
+                "border_parts",
+                outline=self._apply_appearance_mode(self._border_color),
+                fill=self._apply_appearance_mode(self._border_color),
+            )
 
             # set color for inner button parts
             if self._fg_color == "transparent":
-                self._canvas.itemconfig("inner_parts",
-                                        outline=self._apply_appearance_mode(self._bg_color),
-                                        fill=self._apply_appearance_mode(self._bg_color))
+                self._canvas.itemconfig(
+                    "inner_parts",
+                    outline=self._apply_appearance_mode(self._bg_color),
+                    fill=self._apply_appearance_mode(self._bg_color),
+                )
             else:
-                self._canvas.itemconfig("inner_parts",
-                                        outline=self._apply_appearance_mode(self._fg_color),
-                                        fill=self._apply_appearance_mode(self._fg_color))
+                self._canvas.itemconfig(
+                    "inner_parts",
+                    outline=self._apply_appearance_mode(self._fg_color),
+                    fill=self._apply_appearance_mode(self._fg_color),
+                )
 
         # create text label if text given
         if self._text is not None and self._text != "":
-
             if self._text_label is None:
-                self._text_label = tkinter.Label(master=self,
-                                                 font=self._apply_font_scaling(self._font),
-                                                 text=self._text,
-                                                 padx=0,
-                                                 pady=0,
-                                                 borderwidth=1,
-                                                 textvariable=self._textvariable)
+                self._text_label = tkinter.Label(
+                    master=self,
+                    font=self._apply_font_scaling(self._font),
+                    text=self._text,
+                    padx=0,
+                    pady=0,
+                    borderwidth=1,
+                    textvariable=self._textvariable,
+                    anchor=self._text_anchor,
+                )
                 self._create_grid()
 
                 self._text_label.bind("<Enter>", self._on_enter)
@@ -237,17 +310,27 @@ class CTkButton(CTkBaseClass):
 
             if no_color_updates is False:
                 # set text_label fg color (text color)
-                self._text_label.configure(fg=self._apply_appearance_mode(self._text_color))
+                self._text_label.configure(
+                    fg=self._apply_appearance_mode(self._text_color)
+                )
 
                 if self._state == tkinter.DISABLED:
-                    self._text_label.configure(fg=(self._apply_appearance_mode(self._text_color_disabled)))
+                    self._text_label.configure(
+                        fg=(self._apply_appearance_mode(self._text_color_disabled))
+                    )
                 else:
-                    self._text_label.configure(fg=self._apply_appearance_mode(self._text_color))
+                    self._text_label.configure(
+                        fg=self._apply_appearance_mode(self._text_color)
+                    )
 
                 if self._apply_appearance_mode(self._fg_color) == "transparent":
-                    self._text_label.configure(bg=self._apply_appearance_mode(self._bg_color))
+                    self._text_label.configure(
+                        bg=self._apply_appearance_mode(self._bg_color)
+                    )
                 else:
-                    self._text_label.configure(bg=self._apply_appearance_mode(self._fg_color))
+                    self._text_label.configure(
+                        bg=self._apply_appearance_mode(self._fg_color)
+                    )
 
         else:
             # delete text_label if no text given
@@ -258,7 +341,6 @@ class CTkButton(CTkBaseClass):
 
         # create image label if image given
         if self._image is not None:
-
             if self._image_label is None:
                 self._image_label = tkinter.Label(master=self)
                 self._update_image()  # set image
@@ -272,9 +354,13 @@ class CTkButton(CTkBaseClass):
             if no_color_updates is False:
                 # set image_label bg color (background color of label)
                 if self._apply_appearance_mode(self._fg_color) == "transparent":
-                    self._image_label.configure(bg=self._apply_appearance_mode(self._bg_color))
+                    self._image_label.configure(
+                        bg=self._apply_appearance_mode(self._bg_color)
+                    )
                 else:
-                    self._image_label.configure(bg=self._apply_appearance_mode(self._fg_color))
+                    self._image_label.configure(
+                        bg=self._apply_appearance_mode(self._fg_color)
+                    )
 
         else:
             # delete text_label if no text given
@@ -284,13 +370,18 @@ class CTkButton(CTkBaseClass):
                 self._create_grid()
 
     def _create_grid(self):
-        """ configure grid system (5x5) """
+        """configure grid system (5x5)"""
 
         # Outer rows and columns have weight of 1000 to overpower the rows and columns of the label and image with weight 1.
         # Rows and columns of image and label need weight of 1 to collapse in case of missing space on the button,
         # so image and label need sticky option to stick together in the center, and therefore outer rows and columns
         # need weight of 100 in case of other anchor than center.
-        n_padding_weight, s_padding_weight, e_padding_weight, w_padding_weight = 1000, 1000, 1000, 1000
+        n_padding_weight, s_padding_weight, e_padding_weight, w_padding_weight = (
+            1000,
+            1000,
+            1000,
+            1000,
+        )
         if self._anchor != "center":
             if "n" in self._anchor:
                 n_padding_weight, s_padding_weight = 0, 1000
@@ -301,18 +392,30 @@ class CTkButton(CTkBaseClass):
             if "w" in self._anchor:
                 e_padding_weight, w_padding_weight = 0, 1000
 
-        scaled_minsize_rows = self._apply_widget_scaling(max(self._border_width + 1, self._border_spacing))
-        scaled_minsize_columns = self._apply_widget_scaling(max(self._corner_radius, self._border_width + 1, self._border_spacing))
+        scaled_minsize_rows = self._apply_widget_scaling(
+            max(self._border_width + 1, self._border_spacing)
+        )
+        scaled_minsize_columns = self._apply_widget_scaling(
+            max(self._corner_radius, self._border_width + 1, self._border_spacing)
+        )
 
         self.grid_rowconfigure(0, weight=n_padding_weight, minsize=scaled_minsize_rows)
         self.grid_rowconfigure(4, weight=s_padding_weight, minsize=scaled_minsize_rows)
-        self.grid_columnconfigure(0, weight=e_padding_weight, minsize=scaled_minsize_columns)
-        self.grid_columnconfigure(4, weight=w_padding_weight, minsize=scaled_minsize_columns)
+        self.grid_columnconfigure(
+            0, weight=e_padding_weight, minsize=scaled_minsize_columns
+        )
+        self.grid_columnconfigure(
+            4, weight=w_padding_weight, minsize=scaled_minsize_columns
+        )
 
         if self._compound in ("right", "left"):
             self.grid_rowconfigure(2, weight=1)
             if self._image_label is not None and self._text_label is not None:
-                self.grid_columnconfigure(2, weight=0, minsize=self._apply_widget_scaling(self._image_label_spacing))
+                self.grid_columnconfigure(
+                    2,
+                    weight=0,
+                    minsize=self._apply_widget_scaling(self._image_label_spacing),
+                )
             else:
                 self.grid_columnconfigure(2, weight=0)
 
@@ -321,7 +424,11 @@ class CTkButton(CTkBaseClass):
         else:
             self.grid_columnconfigure(2, weight=1)
             if self._image_label is not None and self._text_label is not None:
-                self.grid_rowconfigure(2, weight=0, minsize=self._apply_widget_scaling(self._image_label_spacing))
+                self.grid_rowconfigure(
+                    2,
+                    weight=0,
+                    minsize=self._apply_widget_scaling(self._image_label_spacing),
+                )
             else:
                 self.grid_rowconfigure(2, weight=0)
 
@@ -366,7 +473,9 @@ class CTkButton(CTkBaseClass):
             require_redraw = True
 
         if "fg_color" in kwargs:
-            self._fg_color = self._check_color_type(kwargs.pop("fg_color"), transparency=True)
+            self._fg_color = self._check_color_type(
+                kwargs.pop("fg_color"), transparency=True
+            )
             require_redraw = True
 
         if "hover_color" in kwargs:
@@ -382,7 +491,9 @@ class CTkButton(CTkBaseClass):
             require_redraw = True
 
         if "text_color_disabled" in kwargs:
-            self._text_color_disabled = self._check_color_type(kwargs.pop("text_color_disabled"))
+            self._text_color_disabled = self._check_color_type(
+                kwargs.pop("text_color_disabled")
+            )
             require_redraw = True
 
         if "background_corner_colors" in kwargs:
@@ -505,17 +616,23 @@ class CTkButton(CTkBaseClass):
                 inner_parts_color = self._hover_color
 
             # set color of inner button parts to hover color
-            self._canvas.itemconfig("inner_parts",
-                                    outline=self._apply_appearance_mode(inner_parts_color),
-                                    fill=self._apply_appearance_mode(inner_parts_color))
+            self._canvas.itemconfig(
+                "inner_parts",
+                outline=self._apply_appearance_mode(inner_parts_color),
+                fill=self._apply_appearance_mode(inner_parts_color),
+            )
 
             # set text_label bg color to button hover color
             if self._text_label is not None:
-                self._text_label.configure(bg=self._apply_appearance_mode(inner_parts_color))
+                self._text_label.configure(
+                    bg=self._apply_appearance_mode(inner_parts_color)
+                )
 
             # set image_label bg color to button hover color
             if self._image_label is not None:
-                self._image_label.configure(bg=self._apply_appearance_mode(inner_parts_color))
+                self._image_label.configure(
+                    bg=self._apply_appearance_mode(inner_parts_color)
+                )
 
     def _on_leave(self, event=None):
         self._click_animation_running = False
@@ -526,17 +643,23 @@ class CTkButton(CTkBaseClass):
             inner_parts_color = self._fg_color
 
         # set color of inner button parts
-        self._canvas.itemconfig("inner_parts",
-                                outline=self._apply_appearance_mode(inner_parts_color),
-                                fill=self._apply_appearance_mode(inner_parts_color))
+        self._canvas.itemconfig(
+            "inner_parts",
+            outline=self._apply_appearance_mode(inner_parts_color),
+            fill=self._apply_appearance_mode(inner_parts_color),
+        )
 
         # set text_label bg color (label color)
         if self._text_label is not None:
-            self._text_label.configure(bg=self._apply_appearance_mode(inner_parts_color))
+            self._text_label.configure(
+                bg=self._apply_appearance_mode(inner_parts_color)
+            )
 
         # set image_label bg color (image bg color)
         if self._image_label is not None:
-            self._image_label.configure(bg=self._apply_appearance_mode(inner_parts_color))
+            self._image_label.configure(
+                bg=self._apply_appearance_mode(inner_parts_color)
+            )
 
     def _click_animation(self):
         if self._click_animation_running:
@@ -544,7 +667,6 @@ class CTkButton(CTkBaseClass):
 
     def _clicked(self, event=None):
         if self._state != tkinter.DISABLED:
-
             # click animation: change color with .on_leave() and back to normal after 100ms with click_animation()
             self._on_leave()
             self._click_animation_running = True
@@ -554,15 +676,22 @@ class CTkButton(CTkBaseClass):
                 self._command()
 
     def invoke(self):
-        """ calls command function if button is not disabled """
+        """calls command function if button is not disabled"""
         if self._state != tkinter.DISABLED:
             if self._command is not None:
                 return self._command()
 
-    def bind(self, sequence: str = None, command: Callable = None, add: Union[str, bool] = True):
-        """ called on the tkinter.Canvas """
+    def bind(
+        self,
+        sequence: str = None,
+        command: Callable = None,
+        add: Union[str, bool] = True,
+    ):
+        """called on the tkinter.Canvas"""
         if not (add == "+" or add is True):
-            raise ValueError("'add' argument can only be '+' or True to preserve internal callbacks")
+            raise ValueError(
+                "'add' argument can only be '+' or True to preserve internal callbacks"
+            )
         self._canvas.bind(sequence, command, add=True)
 
         if self._text_label is not None:
@@ -571,10 +700,12 @@ class CTkButton(CTkBaseClass):
             self._image_label.bind(sequence, command, add=True)
 
     def unbind(self, sequence: str = None, funcid: str = None):
-        """ called on the tkinter.Label and tkinter.Canvas """
+        """called on the tkinter.Label and tkinter.Canvas"""
         if funcid is not None:
-            raise ValueError("'funcid' argument can only be None, because there is a bug in" +
-                             " tkinter and its not clear whether the internal callbacks will be unbinded or not")
+            raise ValueError(
+                "'funcid' argument can only be None, because there is a bug in"
+                + " tkinter and its not clear whether the internal callbacks will be unbinded or not"
+            )
         self._canvas.unbind(sequence, None)
 
         if self._text_label is not None:
@@ -582,7 +713,9 @@ class CTkButton(CTkBaseClass):
         if self._image_label is not None:
             self._image_label.unbind(sequence, None)
 
-        self._create_bindings(sequence=sequence)  # restore internal callbacks for sequence
+        self._create_bindings(
+            sequence=sequence
+        )  # restore internal callbacks for sequence
 
     def focus(self):
         return self._text_label.focus()


### PR DESCRIPTION
After encounter an issue where the text of a button was bigger than the width of the button, the text seem justified to the center.
An example:
```python
import customtkinter


def show_value(selected_option):
    print(selected_option)


APP_WIDTH = 200
APP_HEIGHT = 200

root = customtkinter.CTk()

root.geometry(f"{APP_WIDTH}x{APP_HEIGHT}")
root.resizable(width=False, height=False)

button1 = customtkinter.CTkButton(
    root,
    text="A LONG TEXT THAT IS LARGER THAN THE ORIGINAL",
    width=30,
    height=30,
    anchor="w",
    # text_anchor="w",
)
button1.pack(expand=False)

root.mainloop()
```
Resulting in:
![image](https://github.com/TomSchimansky/CustomTkinter/assets/91698253/15f04106-c610-4f16-b38c-d2c61ca87618)

After creating an new argument for the button, being `text_anchor`, and changing the `_draw()` function (adding the argument anchor with the value of the `text_anchor` variable) a the following result can be obtained:
![image](https://github.com/TomSchimansky/CustomTkinter/assets/91698253/dca7e836-eb60-44c7-ab86-e06692f94a2e)

This modification solve this issue, however the argument `border_spacing` seems to not be working with very long texts.

