### PR TITLE
Fixed an exception when destroying a dropdown menu, then rescaling the screen

### DIFF
--- a/customtkinter/windows/widgets/core_widget_classes/dropdown_menu.py
+++ b/customtkinter/windows/widgets/core_widget_classes/dropdown_menu.py
@@ -50,6 +50,7 @@ class DropdownMenu(tkinter.Menu, CTkAppearanceModeBaseClass, CTkScalingBaseClass
         # call destroy methods of super classes
         tkinter.Menu.destroy(self)
         CTkAppearanceModeBaseClass.destroy(self)
+        CTkScalingBaseClass.destroy(self)
 
     def _update_font(self):
         """ pass font to tkinter widgets with applied font scaling """


### PR DESCRIPTION
The __init__ function of the CTkScalingBaseClass is called when creating a DropdownMenu. But the destroy function is never called. This can lead to an exception after destroying a CTkOptionMenu (which uses a DropdownMenu internally).

To reproduce:
1. Create a CTkOptionMenu
2. Destroy that CTkOptionMenu
3. Move the window to another screen with a different scaling factor