### PR TITLE
Implemented CtkSpinBox

### DIFF
--- a/customtkinter/__init__.py
+++ b/customtkinter/__init__.py
@@ -30,6 +30,7 @@ from .windows.widgets import CTkRadioButton
 from .windows.widgets import CTkScrollbar
 from .windows.widgets import CTkSegmentedButton
 from .windows.widgets import CTkSlider
+from .windows.widgets import CTkSpinBox
 from .windows.widgets import CTkSwitch
 from .windows.widgets import CTkTabview
 from .windows.widgets import CTkTextbox

--- a/customtkinter/assets/themes/blue.json
+++ b/customtkinter/assets/themes/blue.json
@@ -100,6 +100,16 @@
     "text_color": ["gray10", "#DCE4EE"],
     "text_color_disabled": ["gray50", "gray45"]
   },
+  "CTkSpinBox": {
+    "corner_radius": 6,
+    "border_width": 2,
+    "fg_color": ["#F9F9FA", "#343638"],
+    "border_color": ["#979DA2", "#565B5E"],
+    "button_color": ["#979DA2", "#565B5E"],
+    "button_hover_color": ["#6E7174", "#7A848D"],
+    "text_color": ["gray10", "#DCE4EE"],
+    "text_color_disabled": ["gray50", "gray45"]
+  },
   "CTkScrollbar": {
     "corner_radius": 1000,
     "border_spacing": 4,

--- a/customtkinter/assets/themes/dark-blue.json
+++ b/customtkinter/assets/themes/dark-blue.json
@@ -100,6 +100,16 @@
     "text_color": ["gray14", "gray84"],
     "text_color_disabled": ["gray50", "gray45"]
   },
+  "CTkSpinBox": {
+    "corner_radius": 6,
+    "border_width": 2,
+    "fg_color": ["#F9F9FA", "#343638"],
+    "border_color": ["#979DA2", "#565B5E"],
+    "button_color": ["#979DA2", "#565B5E"],
+    "button_hover_color": ["#6E7174", "#7A848D"],
+    "text_color": ["gray14", "gray84"],
+    "text_color_disabled": ["gray50", "gray45"]
+  },
   "CTkScrollbar": {
     "corner_radius": 1000,
     "border_spacing": 4,

--- a/customtkinter/assets/themes/green.json
+++ b/customtkinter/assets/themes/green.json
@@ -100,6 +100,16 @@
     "text_color": ["gray10", "#DCE4EE"],
     "text_color_disabled": ["gray50", "gray45"]
   },
+  "CTkSpinBox": {
+    "corner_radius": 6,
+    "border_width": 2,
+    "fg_color": ["#F9F9FA", "#343638"],
+    "border_color": ["#979DA2", "#565B5E"],
+    "button_color": ["#979DA2", "#565B5E"],
+    "button_hover_color": ["#6E7174", "#7A848D"],
+    "text_color": ["gray10", "#DCE4EE"],
+    "text_color_disabled": ["gray50", "gray45"]
+  },
   "CTkScrollbar": {
     "corner_radius": 1000,
     "border_spacing": 4,

--- a/customtkinter/windows/widgets/__init__.py
+++ b/customtkinter/windows/widgets/__init__.py
@@ -10,6 +10,7 @@ from .ctk_radiobutton import CTkRadioButton
 from .ctk_scrollbar import CTkScrollbar
 from .ctk_segmented_button import CTkSegmentedButton
 from .ctk_slider import CTkSlider
+from .ctk_spinbox import CTkSpinBox
 from .ctk_switch import CTkSwitch
 from .ctk_tabview import CTkTabview
 from .ctk_textbox import CTkTextbox

--- a/customtkinter/windows/widgets/core_rendering/draw_engine.py
+++ b/customtkinter/windows/widgets/core_rendering/draw_engine.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import sys
 import math
 import tkinter
-from typing import Union, TYPE_CHECKING
+from typing import Union, Literal, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..core_rendering import CTkCanvas
@@ -22,7 +22,7 @@ class DrawEngine:
      - draw_rounded_slider_with_border_and_button()
      - draw_rounded_scrollbar()
      - draw_checkmark()
-     - draw_dropdown_arrow()
+     - draw_arrow()
 
     """
 
@@ -399,7 +399,7 @@ class DrawEngine:
     def draw_rounded_rect_with_border_vertical_split(self, width: Union[float, int], height: Union[float, int], corner_radius: Union[float, int],
                                                      border_width: Union[float, int], left_section_width: Union[float, int]) -> bool:
         """ Draws a rounded rectangle with a corner_radius and border_width on the canvas which is split at left_section_width.
-            The border elements have the tags 'border_parts_left', 'border_parts_lright',
+            The border elements have the tags 'border_parts_left', 'border_parts_right',
             the main foreground elements have an 'inner_parts_left' and inner_parts_right' tag,
             to color the elements accordingly.
 
@@ -1201,35 +1201,43 @@ class DrawEngine:
 
         return requires_recoloring
 
-    def draw_dropdown_arrow(self, x_position: Union[int, float], y_position: Union[int, float], size: Union[int, float]) -> bool:
-        """ Draws a dropdown bottom facing arrow at (x_position, y_position) in a given size
+    def draw_arrow(self, x_position: Union[int, float], y_position: Union[int, float],
+                   size: Union[int, float], direction: Literal["down", "up"] = "down") -> bool:
+        """ Draws an arrow at (x_position, y_position) in a given size and with required direction
 
             returns bool if recoloring is necessary """
 
         x_position, y_position, size = round(x_position), round(y_position), round(size)
         requires_recoloring = False
 
+        if direction=="down":
+            name = "dropdown_arrow"
+        elif direction=="up":
+            name = "dropup_arrow"
+
         if self.preferred_drawing_method == "polygon_shapes" or self.preferred_drawing_method == "circle_shapes":
-            if not self._canvas.find_withtag("dropdown_arrow"):
-                self._canvas.create_line(0, 0, 0, 0, tags="dropdown_arrow", width=round(size / 3), joinstyle=tkinter.ROUND, capstyle=tkinter.ROUND)
-                self._canvas.tag_raise("dropdown_arrow")
+            if not self._canvas.find_withtag(name):
+                self._canvas.create_line(0, 0, 0, 0, tags=name, width=round(size / 3), joinstyle=tkinter.ROUND, capstyle=tkinter.ROUND)
+                self._canvas.tag_raise(name)
                 requires_recoloring = True
 
-            self._canvas.coords("dropdown_arrow",
+            ymul = -1 if direction=="up" else 1
+            self._canvas.coords(name,
                                 x_position - (size / 2),
-                                y_position - (size / 5),
+                                y_position - (size / 5) * ymul,
                                 x_position,
-                                y_position + (size / 5),
+                                y_position + (size / 5) * ymul,
                                 x_position + (size / 2),
-                                y_position - (size / 5))
+                                y_position - (size / 5) * ymul)
 
         elif self.preferred_drawing_method == "font_shapes":
-            if not self._canvas.find_withtag("dropdown_arrow"):
-                self._canvas.create_text(0, 0, text="Y", font=("CustomTkinter_shapes_font", -size), tags="dropdown_arrow", anchor=tkinter.CENTER)
-                self._canvas.tag_raise("dropdown_arrow")
+            if not self._canvas.find_withtag(name):
+                self._canvas.create_text(0, 0, text="Y", angle=(180 if direction=="up" else 0),
+                                         font=("CustomTkinter_shapes_font", -size), tags=name, anchor=tkinter.CENTER)
+                self._canvas.tag_raise(name)
                 requires_recoloring = True
 
-            self._canvas.itemconfigure("dropdown_arrow", font=("CustomTkinter_shapes_font", -size))
-            self._canvas.coords("dropdown_arrow", x_position, y_position)
+            self._canvas.itemconfigure(name, font=("CustomTkinter_shapes_font", -size))
+            self._canvas.coords(name, x_position, y_position)
 
         return requires_recoloring

--- a/customtkinter/windows/widgets/ctk_optionmenu.py
+++ b/customtkinter/windows/widgets/ctk_optionmenu.py
@@ -192,7 +192,7 @@ class CTkOptionMenu(CTkBaseClass):
                                                                                              0,
                                                                                              self._apply_widget_scaling(left_section_width))
 
-        requires_recoloring_2 = self._draw_engine.draw_dropdown_arrow(self._apply_widget_scaling(self._current_width - (self._current_height / 2)),
+        requires_recoloring_2 = self._draw_engine.draw_arrow(self._apply_widget_scaling(self._current_width - (self._current_height / 2)),
                                                                       self._apply_widget_scaling(self._current_height / 2),
                                                                       self._apply_widget_scaling(self._current_height / 3))
 

--- a/customtkinter/windows/widgets/ctk_spinbox.py
+++ b/customtkinter/windows/widgets/ctk_spinbox.py
@@ -3,7 +3,6 @@ import sys
 import copy
 from typing import Union, Tuple, Callable, List, Optional, Any
 
-from .core_widget_classes import DropdownMenu
 from .core_rendering import CTkCanvas
 from .theme import ThemeManager
 from .core_rendering import DrawEngine
@@ -11,9 +10,9 @@ from .core_widget_classes import CTkBaseClass
 from .font import CTkFont
 
 
-class CTkComboBox(CTkBaseClass):
+class CTkSpinBox(CTkBaseClass):
     """
-    Combobox with dropdown menu, rounded corners, border, variable support.
+    Spinbox with rounded corners, border, variable support.
     For detailed information check out the documentation.
     """
 
@@ -29,19 +28,21 @@ class CTkComboBox(CTkBaseClass):
                  border_color: Optional[Union[str, Tuple[str, str]]] = None,
                  button_color: Optional[Union[str, Tuple[str, str]]] = None,
                  button_hover_color: Optional[Union[str, Tuple[str, str]]] = None,
-                 dropdown_fg_color: Optional[Union[str, Tuple[str, str]]] = None,
-                 dropdown_hover_color: Optional[Union[str, Tuple[str, str]]] = None,
-                 dropdown_text_color: Optional[Union[str, Tuple[str, str]]] = None,
                  text_color: Optional[Union[str, Tuple[str, str]]] = None,
                  text_color_disabled: Optional[Union[str, Tuple[str, str]]] = None,
 
                  font: Optional[Union[tuple, CTkFont]] = None,
-                 dropdown_font: Optional[Union[tuple, CTkFont]] = None,
-                 values: Optional[List[str]] = None,
+                 format: Optional[str] = "{}",
+                 from_: Optional[Union[int, float]] = None,
+                 to: Optional[Union[int, float]] = None,
+                 values: Optional[List] = None,
+                 default_value: Optional[Union[int, float, str]] = None,
+                 step_button: Optional[Union[int, float]] = None,
+                 step_scroll: Optional[Union[int, float]] = None,
                  state: str = tkinter.NORMAL,
                  hover: bool = True,
                  variable: Union[tkinter.Variable, None] = None,
-                 command: Union[Callable[[str], Any], None] = None,
+                 command: Union[Callable[[Union[int, float, str]], Any], None] = None,
                  justify: str = "left",
                  **kwargs):
 
@@ -49,16 +50,16 @@ class CTkComboBox(CTkBaseClass):
         super().__init__(master=master, bg_color=bg_color, width=width, height=height, **kwargs)
 
         # shape
-        self._corner_radius = ThemeManager.theme["CTkComboBox"]["corner_radius"] if corner_radius is None else corner_radius
-        self._border_width = ThemeManager.theme["CTkComboBox"]["border_width"] if border_width is None else border_width
+        self._corner_radius = ThemeManager.theme["CTkSpinBox"]["corner_radius"] if corner_radius is None else corner_radius
+        self._border_width = ThemeManager.theme["CTkSpinBox"]["border_width"] if border_width is None else border_width
 
         # color
-        self._fg_color = ThemeManager.theme["CTkComboBox"]["fg_color"] if fg_color is None else self._check_color_type(fg_color)
-        self._border_color = ThemeManager.theme["CTkComboBox"]["border_color"] if border_color is None else self._check_color_type(border_color)
-        self._button_color = ThemeManager.theme["CTkComboBox"]["button_color"] if button_color is None else self._check_color_type(button_color)
-        self._button_hover_color = ThemeManager.theme["CTkComboBox"]["button_hover_color"] if button_hover_color is None else self._check_color_type(button_hover_color)
-        self._text_color = ThemeManager.theme["CTkComboBox"]["text_color"] if text_color is None else self._check_color_type(text_color)
-        self._text_color_disabled = ThemeManager.theme["CTkComboBox"]["text_color_disabled"] if text_color_disabled is None else self._check_color_type(text_color_disabled)
+        self._fg_color = ThemeManager.theme["CTkSpinBox"]["fg_color"] if fg_color is None else self._check_color_type(fg_color)
+        self._border_color = ThemeManager.theme["CTkSpinBox"]["border_color"] if border_color is None else self._check_color_type(border_color)
+        self._button_color = ThemeManager.theme["CTkSpinBox"]["button_color"] if button_color is None else self._check_color_type(button_color)
+        self._button_hover_color = ThemeManager.theme["CTkSpinBox"]["button_hover_color"] if button_hover_color is None else self._check_color_type(button_hover_color)
+        self._text_color = ThemeManager.theme["CTkSpinBox"]["text_color"] if text_color is None else self._check_color_type(text_color)
+        self._text_color_disabled = ThemeManager.theme["CTkSpinBox"]["text_color_disabled"] if text_color_disabled is None else self._check_color_type(text_color_disabled)
 
         # font
         self._font = CTkFont() if font is None else self._check_font_type(font)
@@ -67,22 +68,28 @@ class CTkComboBox(CTkBaseClass):
 
         # callback and hover functionality
         self._command = command
-        self._variable = variable
+        self._original_variable = variable
         self._state = state
         self._hover = hover
 
-        if values is None:
-            self._values = ["CTkComboBox"]
-        else:
+        # spinbox functionality
+        self._format = format
+        if values is not None:
+            #converted to str to allow index method with Entry's value
             self._values = values
-
-        self._dropdown_menu = DropdownMenu(master=self,
-                                           values=self._values,
-                                           command=self._dropdown_callback,
-                                           fg_color=dropdown_fg_color,
-                                           hover_color=dropdown_hover_color,
-                                           text_color=dropdown_text_color,
-                                           font=dropdown_font)
+            inner = self._format[self._format.index("{"):self._format.index("}")+1]
+            self._formatted_values = list(map(inner.format, self._values))
+        else:
+            self._values = None
+            self._formatted_values = None
+        self._from = from_
+        self._to = to
+        if step_button is None and step_scroll is None:
+            self._step_button = 1
+            self._step_scroll = 1
+        else:
+            self._step_button = step_button if step_button is not None else step_scroll
+            self._step_scroll = step_scroll if step_scroll is not None else step_button
 
         # configure grid system (1x1)
         self.grid_rowconfigure(0, weight=1)
@@ -106,25 +113,43 @@ class CTkComboBox(CTkBaseClass):
         self._create_bindings()
         self._draw()  # initial draw
 
-        if self._variable is not None:
-            self._entry.configure(textvariable=self._variable)
+        if self._original_variable is not None:
+            self._support_variabile = tkinter.StringVar(value=self._format.format(self._original_variable.get()))
+            self._entry.configure(textvariable=self._support_variabile)
+            self._support_variabile.trace_add("write", self._update_original_variable)
+        elif default_value is not None:
+            self.set(default_value)
 
-        # insert default value
-        if self._variable is None:
-            if len(self._values) > 0:
-                self._entry.insert(0, self._values[0])
+    def _update_original_variable(self, *args):
+        value = self.get()
+        if value:
+            try:
+                if isinstance(self._original_variable, tkinter.IntVar):
+                    value = round(float(value))
+                elif isinstance(self._original_variable, tkinter.DoubleVar):
+                    value = float(value)
+                elif isinstance(self._original_variable, tkinter.BooleanVar):
+                    value = bool(value)
+            except ValueError:
+                pass
             else:
-                self._entry.insert(0, "CTkComboBox")
+                self._original_variable.set(value)
 
     def _create_bindings(self, sequence: Optional[str] = None):
         """ set necessary bindings for functionality of widget, will overwrite other bindings """
         if sequence is None:
             self._canvas.tag_bind("right_parts", "<Enter>", self._on_enter)
             self._canvas.tag_bind("dropdown_arrow", "<Enter>", self._on_enter)
+            self._canvas.tag_bind("dropup_arrow", "<Enter>", self._on_enter)
             self._canvas.tag_bind("right_parts", "<Leave>", self._on_leave)
             self._canvas.tag_bind("dropdown_arrow", "<Leave>", self._on_leave)
+            self._canvas.tag_bind("dropup_arrow", "<Leave>", self._on_leave)
             self._canvas.tag_bind("right_parts", "<Button-1>", self._clicked)
             self._canvas.tag_bind("dropdown_arrow", "<Button-1>", self._clicked)
+            self._canvas.tag_bind("dropup_arrow", "<Button-1>", self._clicked)
+            self._canvas.bind("<MouseWheel>", self._clicked)
+            self._entry.bind("<MouseWheel>", self._clicked)
+            self._entry.bind("<FocusOut>", self._clicked) #to force format if user updates manually
 
     def _create_grid(self):
         self._canvas.grid(row=0, column=0, rowspan=1, columnspan=1, sticky="nsew")
@@ -179,10 +204,16 @@ class CTkComboBox(CTkBaseClass):
                                                                                             self._apply_widget_scaling(left_section_width))
 
         requires_recoloring_2 = self.draw_engine.draw_arrow(self._apply_widget_scaling(self._current_width - (self._current_height / 2)),
-                                                                     self._apply_widget_scaling(self._current_height / 2),
-                                                                     self._apply_widget_scaling(self._current_height / 3))
+                                                                     self._apply_widget_scaling(self._current_height / 3 * 2),
+                                                                     self._apply_widget_scaling(self._current_height / 3),
+                                                                     direction="down")
 
-        if no_color_updates is False or requires_recoloring or requires_recoloring_2:
+        requires_recoloring_3 = self.draw_engine.draw_arrow(self._apply_widget_scaling(self._current_width - (self._current_height / 2)),
+                                                                     self._apply_widget_scaling(self._current_height / 3),
+                                                                     self._apply_widget_scaling(self._current_height / 3),
+                                                                     direction="up")
+
+        if no_color_updates is False or requires_recoloring or requires_recoloring_2 or requires_recoloring_3:
 
             self._canvas.configure(bg=self._apply_appearance_mode(self._bg_color))
 
@@ -210,13 +241,13 @@ class CTkComboBox(CTkBaseClass):
             if self._state == tkinter.DISABLED:
                 self._canvas.itemconfig("dropdown_arrow",
                                         fill=self._apply_appearance_mode(self._text_color_disabled))
+                self._canvas.itemconfig("dropup_arrow",
+                                        fill=self._apply_appearance_mode(self._text_color_disabled))
             else:
                 self._canvas.itemconfig("dropdown_arrow",
                                         fill=self._apply_appearance_mode(self._text_color))
-
-    def _open_dropdown_menu(self):
-        self._dropdown_menu.open(self.winfo_rootx(),
-                                 self.winfo_rooty() + self._apply_widget_scaling(self._current_height + 0))
+                self._canvas.itemconfig("dropup_arrow",
+                                        fill=self._apply_appearance_mode(self._text_color))
 
     def configure(self, require_redraw=False, **kwargs):
         if "corner_radius" in kwargs:
@@ -244,15 +275,6 @@ class CTkComboBox(CTkBaseClass):
             self._button_hover_color = self._check_color_type(kwargs.pop("button_hover_color"))
             require_redraw = True
 
-        if "dropdown_fg_color" in kwargs:
-            self._dropdown_menu.configure(fg_color=kwargs.pop("dropdown_fg_color"))
-
-        if "dropdown_hover_color" in kwargs:
-            self._dropdown_menu.configure(hover_color=kwargs.pop("dropdown_hover_color"))
-
-        if "dropdown_text_color" in kwargs:
-            self._dropdown_menu.configure(text_color=kwargs.pop("dropdown_text_color"))
-
         if "text_color" in kwargs:
             self._text_color = self._check_color_type(kwargs.pop("text_color"))
             require_redraw = True
@@ -270,12 +292,36 @@ class CTkComboBox(CTkBaseClass):
 
             self._update_font()
 
-        if "dropdown_font" in kwargs:
-            self._dropdown_menu.configure(font=kwargs.pop("dropdown_font"))
-
         if "values" in kwargs:
-            self._values = kwargs.pop("values")
-            self._dropdown_menu.configure(values=self._values)
+            self._values = list(map(str, kwargs.pop("values")))
+            inner = self._format[self._format.index("{"):self._format.index("}")+1]
+            self._formatted_values = list(map(inner.format, self._values))
+            self.set(self.get()) #to verify current value is still valid
+        
+        if "from_" in kwargs:
+            self._from = kwargs.pop("from_")
+            self.set(self.get()) #to clamp current value to new limit
+        
+        if "to" in kwargs:
+            self._to = kwargs.pop("to")
+            self.set(self.get()) #to clamp current value to new limit
+        
+        if "format" in kwargs:
+            value = self.get()
+            self._format = kwargs.pop("format")
+            if self._values is not None:
+                inner = self._format[self._format.index("{"):self._format.index("}")+1]
+                self._formatted_values = list(map(inner.format, self._values))
+            self.set(value) #to update current value's format
+        
+        if "step_button" in kwargs:
+            self._step_button = kwargs.pop("step_button")
+        
+        if "step_scroll" in kwargs:
+            self._step_scroll = kwargs.pop("step_scroll")
+        
+        if "default_value" in kwargs:
+            kwargs.pop("default_value")
 
         if "state" in kwargs:
             self._state = kwargs.pop("state")
@@ -286,8 +332,8 @@ class CTkComboBox(CTkBaseClass):
             self._hover = kwargs.pop("hover")
 
         if "variable" in kwargs:
-            self._variable = kwargs.pop("variable")
-            self._entry.configure(textvariable=self._variable)
+            self._original_variable = kwargs.pop("variable")
+            self._entry.configure(textvariable=self._original_variable)
 
         if "command" in kwargs:
             self._command = kwargs.pop("command")
@@ -311,12 +357,6 @@ class CTkComboBox(CTkBaseClass):
             return self._button_color
         elif attribute_name == "button_hover_color":
             return self._button_hover_color
-        elif attribute_name == "dropdown_fg_color":
-            return self._dropdown_menu.cget("fg_color")
-        elif attribute_name == "dropdown_hover_color":
-            return self._dropdown_menu.cget("hover_color")
-        elif attribute_name == "dropdown_text_color":
-            return self._dropdown_menu.cget("text_color")
         elif attribute_name == "text_color":
             return self._text_color
         elif attribute_name == "text_color_disabled":
@@ -324,16 +364,26 @@ class CTkComboBox(CTkBaseClass):
 
         elif attribute_name == "font":
             return self._font
-        elif attribute_name == "dropdown_font":
-            return self._dropdown_menu.cget("font")
         elif attribute_name == "values":
             return copy.copy(self._values)
+        elif attribute_name in ["from_", "from"]:
+            return self._from
+        elif attribute_name == "to":
+            return self._to
+        elif attribute_name == "format":
+            return self._format
+        elif attribute_name == "step_button":
+            return self._step_button
+        elif attribute_name == "step_scroll":
+            return self._step_scroll
+        elif attribute_name == "default_value":
+            return "#N/A"
         elif attribute_name == "state":
             return self._state
         elif attribute_name == "hover":
             return self._hover
         elif attribute_name == "variable":
-            return self._variable
+            return self._original_variable
         elif attribute_name == "command":
             return self._command
         elif attribute_name == "justify":
@@ -342,10 +392,10 @@ class CTkComboBox(CTkBaseClass):
             return super().cget(attribute_name)
 
     def _on_enter(self, event=0):
-        if self._hover is True and self._state == tkinter.NORMAL and len(self._values) > 0:
-            if sys.platform == "darwin" and len(self._values) > 0 and self._cursor_manipulation_enabled:
+        if self._hover is True and self._state == tkinter.NORMAL:
+            if sys.platform == "darwin" and self._cursor_manipulation_enabled:
                 self._canvas.configure(cursor="pointinghand")
-            elif sys.platform.startswith("win") and len(self._values) > 0 and self._cursor_manipulation_enabled:
+            elif sys.platform.startswith("win") and self._cursor_manipulation_enabled:
                 self._canvas.configure(cursor="hand2")
 
             # set color of inner button parts to hover color
@@ -357,9 +407,9 @@ class CTkComboBox(CTkBaseClass):
                                     fill=self._apply_appearance_mode(self._button_hover_color))
 
     def _on_leave(self, event=0):
-        if sys.platform == "darwin" and len(self._values) > 0 and self._cursor_manipulation_enabled:
+        if sys.platform == "darwin" and self._cursor_manipulation_enabled:
             self._canvas.configure(cursor="arrow")
-        elif sys.platform.startswith("win") and len(self._values) > 0 and self._cursor_manipulation_enabled:
+        elif sys.platform.startswith("win") and self._cursor_manipulation_enabled:
             self._canvas.configure(cursor="arrow")
 
         # set color of inner button parts
@@ -370,35 +420,69 @@ class CTkComboBox(CTkBaseClass):
                                 outline=self._apply_appearance_mode(self._button_color),
                                 fill=self._apply_appearance_mode(self._button_color))
 
-    def _dropdown_callback(self, value: str):
+    def set(self, value: Union[int, float, str]):
+        formatted_value = self._format.format(value)
+
         if self._state == "readonly":
             self._entry.configure(state="normal")
             self._entry.delete(0, tkinter.END)
-            self._entry.insert(0, value)
+            self._entry.insert(0, formatted_value)
             self._entry.configure(state="readonly")
         else:
             self._entry.delete(0, tkinter.END)
-            self._entry.insert(0, value)
-
-        if self._command is not None:
-            self._command(value)
-
-    def set(self, value: str):
-        if self._state == "readonly":
-            self._entry.configure(state="normal")
-            self._entry.delete(0, tkinter.END)
-            self._entry.insert(0, value)
-            self._entry.configure(state="readonly")
-        else:
-            self._entry.delete(0, tkinter.END)
-            self._entry.insert(0, value)
+            self._entry.insert(0, formatted_value)
 
     def get(self) -> str:
-        return self._entry.get()
+        value = self._entry.get()
+        pre = self._format.split("{")[0]
+        post = self._format.split("}")[-1]
+        value = value.replace(pre, "")
+        value = value.replace(post, "")
+        return value
 
-    def _clicked(self, event=None):
-        if self._state is not tkinter.DISABLED and len(self._values) > 0:
-            self._open_dropdown_menu()
+    def _clicked(self, event: tkinter.Event=None):
+        if self._state is not tkinter.DISABLED:
+            if event.type == tkinter.EventType.ButtonPress:
+                is_up = event.y < self._canvas.winfo_height() / 2
+                delta = self._step_button
+            elif event.type == tkinter.EventType.MouseWheel:
+                is_up = event.delta > 0
+                delta = self._step_scroll
+            else:
+                is_up = False
+                delta = 0
+            if not is_up:
+                delta = -delta
+
+            current_value = self.get()
+
+            if self._values is not None and self._values:
+                try:
+                    idx = self._formatted_values.index(current_value) + delta
+                except ValueError:
+                    idx = 0 if is_up else -1
+                else:
+                    idx = 0 if idx < 0 else idx
+                    idx = -1 if idx >= len(self._values) else idx
+                new_value = self._values[idx]
+            else:
+                try:
+                    if current_value.find(".") < 0:
+                        new_value = int(current_value) + delta
+                    else:
+                        new_value = float(current_value) + delta
+                except ValueError:
+                    new_value = 0
+
+                if self._from is not None and new_value < self._from:
+                    new_value = self._from
+                if self._to is not None and new_value > self._to:
+                    new_value = self._to
+
+            self.set(new_value)
+
+            if self._command is not None:
+                self._command(new_value)
 
     def bind(self, sequence=None, command=None, add=True):
         """ called on the tkinter.Entry """

--- a/examples/complex_example.py
+++ b/examples/complex_example.py
@@ -64,13 +64,16 @@ class App(customtkinter.CTk):
 
         self.optionmenu_1 = customtkinter.CTkOptionMenu(self.tabview.tab("CTkTabview"), dynamic_resizing=False,
                                                         values=["Value 1", "Value 2", "Value Long Long Long"])
-        self.optionmenu_1.grid(row=0, column=0, padx=20, pady=(20, 10))
+        self.optionmenu_1.grid(row=0, column=0, padx=20, pady=(20, 5))
         self.combobox_1 = customtkinter.CTkComboBox(self.tabview.tab("CTkTabview"),
                                                     values=["Value 1", "Value 2", "Value Long....."])
-        self.combobox_1.grid(row=1, column=0, padx=20, pady=(10, 10))
+        self.combobox_1.grid(row=1, column=0, padx=20, pady=(5, 5))
+        self.spinbox_1 = customtkinter.CTkSpinBox(self.tabview.tab("CTkTabview"),
+                                                  from_=0, to=100, step_button=0.5, step_scroll=5)
+        self.spinbox_1.grid(row=2, column=0, padx=20, pady=(5, 5))
         self.string_input_button = customtkinter.CTkButton(self.tabview.tab("CTkTabview"), text="Open CTkInputDialog",
                                                            command=self.open_input_dialog_event)
-        self.string_input_button.grid(row=2, column=0, padx=20, pady=(10, 10))
+        self.string_input_button.grid(row=3, column=0, padx=20, pady=(5, 5))
         self.label_tab_2 = customtkinter.CTkLabel(self.tabview.tab("Tab 2"), text="CTkLabel on Tab 2")
         self.label_tab_2.grid(row=0, column=0, padx=20, pady=20)
 
@@ -136,6 +139,7 @@ class App(customtkinter.CTk):
         self.scaling_optionemenu.set("100%")
         self.optionmenu_1.set("CTkOptionmenu")
         self.combobox_1.set("CTkComboBox")
+        self.spinbox_1.set("CTkSpinBox")
         self.slider_1.configure(command=self.progressbar_2.set)
         self.slider_2.configure(command=self.progressbar_3.set)
         self.progressbar_1.configure(mode="indeterminnate")

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -47,6 +47,10 @@ combobox_1 = customtkinter.CTkComboBox(frame_1, values=["Option 1", "Option 2", 
 combobox_1.pack(pady=10, padx=10)
 combobox_1.set("CTkComboBox")
 
+spinbox_1 = customtkinter.CTkSpinBox(frame_1, from_=0, to=100, step_button=0.5, step_scroll=5)
+spinbox_1.pack(pady=10, padx=10)
+spinbox_1.set("CTkSpinBox")
+
 checkbox_1 = customtkinter.CTkCheckBox(master=frame_1)
 checkbox_1.pack(pady=10, padx=10)
 


### PR DESCRIPTION
Implemented the true CtkSpinBox by copying CtkComboBox and performing the needed changes.

![image](https://github.com/TomSchimansky/CustomTkinter/assets/160390475/a6aa963b-1d88-4342-b95a-fecdb764ad52)

I didn't dare to touch `DrawEngine.draw_rounded_rect_with_border_vertical_split()`, so for now there is just one button and I discern the "up" or "down" section by looking at the relative mouse position within the canvas. This has the side effect that when you hover on it with the mouse, both "buttons" are highlighted simultaneously, but it's not that ugly.

Parameters `from_` and `to` impose limits to the number that can be displayed, while by providing the `value` parameter, you can pick elements from any List. Thanks to `step_button` and `step_scroll` parameters you can choose how much the value (or List index) is changed if you click a button or scroll the mouse wheel respectively. `default_value` is self-explanatory but it is effective only if a `tkinter.Variable` is not provided. Finally, the `format` parameter is used to invoke the `format()` method on it to display other text that is not part of the value (for example, measurement units).