### PR TITLE
Update ctk_base_class.py  :  about place method

### DIFF
--- a/customtkinter/windows/widgets/core_widget_classes/ctk_base_class.py
+++ b/customtkinter/windows/widgets/core_widget_classes/ctk_base_class.py
@@ -268,8 +268,12 @@ class CTkBaseClass(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBaseClas
         relheight=amount - height of this widget between 0.0 and 1.0 relative to height of master (1.0 is the same height as the master)
         bordermode="inside" or "outside" - whether to take border width of master widget into account
         """
+        #remove this
+        """
         if "width" in kwargs or "height" in kwargs:
             raise ValueError("'width' and 'height' arguments must be passed to the constructor of the widget, not the place method")
+        """
+        
         self._last_geometry_manager_call = {"function": super().place, "kwargs": kwargs}
         return super().place(**self._apply_argument_scaling(kwargs))
 


### PR DESCRIPTION
# Enabling User to Pass Width and Height to the Place Method

Customtkinter not allows users to pass width and height arguments to the place method, but it's really usefull in tkinter.

```
self.link_entry = ctk.CTkEntry(master=self, height=40)
self.add_btn =  ctk.CTkButton(master=self, text="Add +", height=40, width=200)
self.link_entry.place(relwidth=1, width=-210)
self.add_btn.place(relx=1, x=-200)
```

https://github.com/TomSchimansky/CustomTkinter/assets/93121062/fd8fe730-3b9b-4e60-a106-fc3b48fdddce
