### PR TITLE
Add events for the scroll wheel in Linux.

### DIFF
--- a/customtkinter/windows/widgets/ctk_scrollable_frame.py
+++ b/customtkinter/windows/widgets/ctk_scrollable_frame.py
@@ -75,6 +75,8 @@ class CTkScrollableFrame(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBa
         self.bind("<Configure>", lambda e: self._parent_canvas.configure(scrollregion=self._parent_canvas.bbox("all")))
         self._parent_canvas.bind("<Configure>", self._fit_frame_dimensions_to_canvas)
         self.bind_all("<MouseWheel>", self._mouse_wheel_all, add="+")
+        self.bind_all("<Button-4>", self._mouse_wheel_all, add="+")
+        self.bind_all("<Button-5>", self._mouse_wheel_all, add="+")
         self.bind_all("<KeyPress-Shift_L>", self._keyboard_shift_press_all, add="+")
         self.bind_all("<KeyPress-Shift_R>", self._keyboard_shift_press_all, add="+")
         self.bind_all("<KeyRelease-Shift_L>", self._keyboard_shift_release_all, add="+")
@@ -263,10 +265,10 @@ class CTkScrollableFrame(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBa
             else:
                 if self._shift_pressed:
                     if self._parent_canvas.xview() != (0.0, 1.0):
-                        self._parent_canvas.xview("scroll", -event.delta, "units")
+                        self._parent_canvas.xview("scroll", -10 if event.num == 4 else 10, "units")
                 else:
                     if self._parent_canvas.yview() != (0.0, 1.0):
-                        self._parent_canvas.yview("scroll", -event.delta, "units")
+                        self._parent_canvas.yview("scroll", -10 if event.num == 4 else 10, "units")
 
     def _keyboard_shift_press_all(self, event):
         self._shift_pressed = True

--- a/customtkinter/windows/widgets/ctk_scrollbar.py
+++ b/customtkinter/windows/widgets/ctk_scrollbar.py
@@ -86,6 +86,9 @@ class CTkScrollbar(CTkBaseClass):
             self._canvas.bind("<B1-Motion>", self._clicked)
         if sequence is None or sequence == "<MouseWheel>":
             self._canvas.bind("<MouseWheel>", self._mouse_scroll_event)
+        if sequence is None or sequence == "<Button-4>" or sequence == "<Button-5>":
+            self._canvas.bind("<Button-4>", self._mouse_scroll_event)
+            self._canvas.bind("<Button-5>", self._mouse_scroll_event)
 
     def _set_scaling(self, *args, **kwargs):
         super()._set_scaling(*args, **kwargs)
@@ -246,8 +249,10 @@ class CTkScrollbar(CTkBaseClass):
         if self._command is not None:
             if sys.platform.startswith("win"):
                 self._command('scroll', -int(event.delta/40), 'units')
-            else:
+            elif sys.platform == "darwin":
                 self._command('scroll', -event.delta, 'units')
+            else:
+                self._command('scroll', -10 if event.num == 4 else 10, 'units')
 
     def set(self, start_value: float, end_value: float):
         self._start_value = float(start_value)


### PR DESCRIPTION
# My project uses several widgets, however I notice that the scroll wheel does not work on Linux.
In these two files, I add the events to buttons 4 and 5 (along with MouseWheel for Windows and MacOS) and assign a value for each interaction with button 4 (or 5).

## Warning
I warn everyone about adding more events with other buttons (1, 2 and 3): in this case, these events maybe affect the user experience with the scroll wheel on Linux, because they interact with the conditional in self._parent_canvas.(x|y )view.

## Thank you.