### PR TITLE
Add conditional check for keyword argument 'value' in configure metho…

### DIFF
--- a/customtkinter/windows/widgets/ctk_radiobutton.py
+++ b/customtkinter/windows/widgets/ctk_radiobutton.py
@@ -276,6 +276,9 @@ class CTkRadioButton(CTkBaseClass):
             self._textvariable = kwargs.pop("textvariable")
             self._text_label.configure(textvariable=self._textvariable)
 
+        if "value" in kwargs:
+            self._value = kwargs.pop("value")
+
         if "variable" in kwargs:
             if self._variable is not None:
                 self._variable.trace_remove("write", self._variable_callback_name)


### PR DESCRIPTION
the customtkinter.CTkRadioButton class' configure method throws an error when called with 'value' keyword argument eg: 
radio_button = CTkRadioButton(master)
radio_button.configure(value = 2) 

This is solved by adding an if statement to check for the 'value' kwarg and thus update the _value variable in the class.