### PR TITLE
BUG list update : scaling_tracker.py

### DIFF
--- a/customtkinter/windows/widgets/scaling/scaling_tracker.py
+++ b/customtkinter/windows/widgets/scaling/scaling_tracker.py
@@ -174,7 +174,7 @@ class ScalingTracker:
         new_scaling_detected = False
 
         # check for every window if scaling value changed
-        for window in cls.window_widgets_dict:
+        for window in list(cls.window_widgets_dict):
             if window.winfo_exists() and not window.state() == "iconic":
                 current_dpi_scaling_value = cls.get_window_dpi_scaling(window)
                 if current_dpi_scaling_value != cls.window_dpi_scaling_dict[window]:


### PR DESCRIPTION
✒🇬🇧 Exeplication :
This is because the size of the cls.window_widgets_dict dictionary changes during iteration. This means that an element is added to or removed from the dictionary while the for loop is running, resulting in the RuntimeError.

✒🇫🇷 Explication :
C'est dû au fait que la taille du dictionnaire cls.window_widgets_dict change pendant l'itération. Cela signifie qu'un élément est ajouté ou supprimé du dictionnaire pendant que la boucle for est en cours, ce qui entraîne l'erreur RuntimeError.


🖥 Console : 
```
Exception in Tkinter callback
Traceback (most recent call last):
File "***\Programs\Python\Python311\Lib\tkinter\__init__.py", line 1948, in __call__
    return self.func(*args)
           ^^^^^^^^^^^^^^^^
File "***\Programs\Python\Python311\Lib\tkinter\__init__.py", line 861, in callit
    func(*args)
File "***\Programs\Python\Python311\Lib\site-packages\customtkinter\windows\widgets\scaling\scaling_tracker.py", line 177, in check_dpi_scaling
    for window in cls.window_widgets_dict:
RuntimeError: dictionary changed size during iteration
```