### PR TITLE
Fixed locale-dependent canvas scaling bug

### DIFF
--- a/customtkinter/windows/widgets/scaling/scaling_base_class.py
+++ b/customtkinter/windows/widgets/scaling/scaling_base_class.py
@@ -57,13 +57,24 @@ class CTkScalingBaseClass:
     def _get_window_scaling(self) -> float:
         return self.__window_scaling
 
-    def _apply_widget_scaling(self, value: Union[int, float]) -> Union[float]:
+    # Some parts of Tk - notably canvas - are very buggy with floats, because they use locale-dependent parsing
+    # (and thus might not recognize "." as the decimal point)
+    # https://wiki.tcl-lang.org/page/locale
+    # https://github.com/python/cpython/issues/56767
+    # Hence, we must ensure any integer value stays that way
+    def _apply_widget_scaling(self, value: Union[int, float]) -> Union[int, float]:
         assert self.__scaling_type == "widget"
-        return value * self.__widget_scaling
+        if isinstance(value, float):
+            return value * self.__widget_scaling
+        else:
+            return int(value * self.__widget_scaling)
 
-    def _reverse_widget_scaling(self, value: Union[int, float]) -> Union[float]:
+    def _reverse_widget_scaling(self, value: Union[int, float]) -> Union[int, float]:
         assert self.__scaling_type == "widget"
-        return value / self.__widget_scaling
+        if isinstance(value, float):
+            return value / self.__widget_scaling
+        else:
+            return int(value / self.__widget_scaling)
 
     def _apply_window_scaling(self, value: Union[int, float]) -> int:
         assert self.__scaling_type == "window"

--- a/test/manual_integration_tests/test_scaling/test_scaling_simple_place.py
+++ b/test/manual_integration_tests/test_scaling/test_scaling_simple_place.py
@@ -1,6 +1,8 @@
+import locale
 import tkinter
 import customtkinter  # <- import the CustomTkinter module
 
+locale.setlocale(locale.LC_NUMERIC, 'de_DE')  # to verify that the canvas float argument bug is properly averted
 customtkinter.ScalingTracker.set_window_scaling(0.5)
 
 customtkinter.set_appearance_mode("dark")  # Modes: "System" (standard), "Dark", "Light"

--- a/test/manual_integration_tests/test_scaling/test_scaling_toplevel_pack.py
+++ b/test/manual_integration_tests/test_scaling/test_scaling_toplevel_pack.py
@@ -1,6 +1,8 @@
+import locale
 import tkinter
 import customtkinter  # <- import the CustomTkinter module
 
+locale.setlocale(locale.LC_NUMERIC, 'de_DE')  # to verify that the canvas float argument bug is properly averted
 customtkinter.ScalingTracker.set_window_scaling(0.5)
 
 customtkinter.set_appearance_mode("dark")  # Modes: "System" (standard), "Dark", "Light"


### PR DESCRIPTION
Closes #571

Currently CTk _does not run at all_ under some locales (such as German and Portuguese) because the widget scaling triggers an ancient Tk canvas bug.
So, despite the rich active ecosystem, it's outright unusable for any i18n-aware applications.

This solution is not mine - it was posted a while ago on the issue comments - but I documented it and added a locale on the scaling integration tests to detect regressions.