### PR TITLE
fixing the display of the simple_example.py file

### DIFF
--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -1,7 +1,7 @@
 import customtkinter
-import tkinterDnD
+import tkinter
 
-customtkinter.set_ctk_parent_class(tkinterDnD.Tk)
+customtkinter.set_ctk_parent_class(tkinter.Tk)
 
 customtkinter.set_appearance_mode("dark")  # Modes: "System" (standard), "Dark", "Light"
 customtkinter.set_default_color_theme("blue")  # Themes: "blue" (standard), "green", "dark-blue"
@@ -10,7 +10,7 @@ app = customtkinter.CTk()
 app.geometry("400x780")
 app.title("CustomTkinter simple_example.py")
 
-print(type(app), isinstance(app, tkinterDnD.Tk))
+print(type(app), isinstance(app, tkinter.Tk))
 
 def button_callback():
     print("Button click", combobox_1.get())


### PR DESCRIPTION
Here I made a simple fix so that when running the simple_example.py file it does not display the error caused by using TkinterDnD