### PR TITLE
add sensitive scrollbar feature

### DIFF
--- a/customtkinter/windows/widgets/ctk_scrollable_frame.py
+++ b/customtkinter/windows/widgets/ctk_scrollable_frame.py
@@ -102,7 +102,7 @@ class CTkScrollableFrame(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBa
             self._parent_frame.grid_columnconfigure(0, weight=1)
             self._parent_frame.grid_rowconfigure(1, weight=1)
             self._parent_canvas.grid(row=1, column=0, sticky="nsew", padx=border_spacing, pady=(border_spacing, 0))
-            self._scrollbar.grid(row=2, column=0, sticky="nsew", padx=border_spacing)
+            self._update_scrollbar(border_spacing)
 
             if self._label_text is not None and self._label_text != "":
                 self._label.grid(row=0, column=0, sticky="ew", padx=border_spacing, pady=border_spacing)
@@ -113,7 +113,7 @@ class CTkScrollableFrame(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBa
             self._parent_frame.grid_columnconfigure(0, weight=1)
             self._parent_frame.grid_rowconfigure(1, weight=1)
             self._parent_canvas.grid(row=1, column=0, sticky="nsew", padx=(border_spacing, 0), pady=border_spacing)
-            self._scrollbar.grid(row=1, column=1, sticky="nsew", pady=border_spacing)
+            self._update_scrollbar(border_spacing)
 
             if self._label_text is not None and self._label_text != "":
                 self._label.grid(row=0, column=0, columnspan=2, sticky="ew", padx=border_spacing, pady=border_spacing)
@@ -235,8 +235,27 @@ class CTkScrollableFrame(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBa
     def _fit_frame_dimensions_to_canvas(self, event):
         if self._orientation == "horizontal":
             self._parent_canvas.itemconfigure(self._create_window_id, height=self._parent_canvas.winfo_height())
+            if self._parent_canvas.xview() != (0.0, 1.0):
+                self._update_scrollbar()
         elif self._orientation == "vertical":
             self._parent_canvas.itemconfigure(self._create_window_id, width=self._parent_canvas.winfo_width())
+            if self._parent_canvas.yview() != (0.0, 1.0):
+                self._update_scrollbar()
+
+    def _update_scrollbar(self, border_spacing=None):
+        if border_spacing is None:
+            border_spacing = self._apply_widget_scaling(
+                self._parent_frame.cget("corner_radius") + self._parent_frame.cget("border_width"))
+        if self._orientation == "horizontal":
+            if self._parent_canvas.xview() != (0.0, 1.0):
+                self._scrollbar.grid(row=2, column=0, sticky="nsew", padx=border_spacing)
+            else:
+                self._scrollbar.grid_remove()
+        elif self._orientation == "vertical":
+            if self._parent_canvas.yview() != (0.0, 1.0):
+                self._scrollbar.grid(row=1, column=1, sticky="nsew", padx=border_spacing)
+            else:
+                self._scrollbar.grid_remove()
 
     def _set_scroll_increments(self):
         if sys.platform.startswith("win"):


### PR DESCRIPTION
Originally, scrollbar in scrollable frame is displayed regardless whether it is necessary. If the content size is smaller than the frame size, the scrollbar of that scrollable frame is not necessary to be displayed. I added a few lines of code to check whether it is necessary to display scrollbar in that frame as <Configure> event is happened.