### PR TITLE
Fixed: Scrollbar Covers The Borders In ScrollableFrame

### DIFF
--- a/customtkinter/windows/widgets/ctk_scrollable_frame.py
+++ b/customtkinter/windows/widgets/ctk_scrollable_frame.py
@@ -43,6 +43,7 @@ class CTkScrollableFrame(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBa
         # dimensions independent of scaling
         self._desired_width = width  # _desired_width and _desired_height, represent desired size set by width and height
         self._desired_height = height
+        self._border_width = border_width if border_width else 0
 
         self._parent_frame = CTkFrame(master=master, width=0, height=0, corner_radius=corner_radius,
                                       border_width=border_width, bg_color=bg_color, fg_color=fg_color, border_color=border_color)
@@ -102,7 +103,7 @@ class CTkScrollableFrame(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBa
             self._parent_frame.grid_columnconfigure(0, weight=1)
             self._parent_frame.grid_rowconfigure(1, weight=1)
             self._parent_canvas.grid(row=1, column=0, sticky="nsew", padx=border_spacing, pady=(border_spacing, 0))
-            self._scrollbar.grid(row=2, column=0, sticky="nsew", padx=border_spacing)
+            self._scrollbar.grid(row=2, column=0, sticky="nsew", padx=border_spacing + self._border_width)
 
             if self._label_text is not None and self._label_text != "":
                 self._label.grid(row=0, column=0, sticky="ew", padx=border_spacing, pady=border_spacing)
@@ -113,7 +114,7 @@ class CTkScrollableFrame(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBa
             self._parent_frame.grid_columnconfigure(0, weight=1)
             self._parent_frame.grid_rowconfigure(1, weight=1)
             self._parent_canvas.grid(row=1, column=0, sticky="nsew", padx=(border_spacing, 0), pady=border_spacing)
-            self._scrollbar.grid(row=1, column=1, sticky="nsew", pady=border_spacing)
+            self._scrollbar.grid(row=1, column=1, sticky="nsew", pady=border_spacing + self._border_width)
 
             if self._label_text is not None and self._label_text != "":
                 self._label.grid(row=0, column=0, columnspan=2, sticky="ew", padx=border_spacing, pady=border_spacing)
@@ -160,6 +161,7 @@ class CTkScrollableFrame(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBa
             self._create_grid()
 
         if "border_width" in kwargs:
+            self._border_width = kwargs.pop("border_width")
             self._parent_frame.configure(border_width=kwargs.pop("border_width"))
             self._create_grid()
 

--- a/customtkinter/windows/widgets/ctk_scrollable_frame.py
+++ b/customtkinter/windows/widgets/ctk_scrollable_frame.py
@@ -100,10 +100,11 @@ class CTkScrollableFrame(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBa
         border_spacing = self._apply_widget_scaling(self._parent_frame.cget("corner_radius") + self._parent_frame.cget("border_width"))
 
         if self._orientation == "horizontal":
+            border_padding = self._border_width*2
             self._parent_frame.grid_columnconfigure(0, weight=1)
             self._parent_frame.grid_rowconfigure(1, weight=1)
             self._parent_canvas.grid(row=1, column=0, sticky="nsew", padx=border_spacing, pady=(border_spacing, 0))
-            self._scrollbar.grid(row=2, column=0, sticky="nsew", padx=border_spacing + self._border_width)
+            self._scrollbar.grid(row=2, column=0, sticky="nsew", padx=border_spacing, pady=border_padding)
 
             if self._label_text is not None and self._label_text != "":
                 self._label.grid(row=0, column=0, sticky="ew", padx=border_spacing, pady=border_spacing)
@@ -111,10 +112,11 @@ class CTkScrollableFrame(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBa
                 self._label.grid_forget()
 
         elif self._orientation == "vertical":
+            border_padding = self._border_width*2
             self._parent_frame.grid_columnconfigure(0, weight=1)
             self._parent_frame.grid_rowconfigure(1, weight=1)
             self._parent_canvas.grid(row=1, column=0, sticky="nsew", padx=(border_spacing, 0), pady=border_spacing)
-            self._scrollbar.grid(row=1, column=1, sticky="nsew", pady=border_spacing + self._border_width)
+            self._scrollbar.grid(row=1, column=1, sticky="nsew", padx=border_padding, pady=border_spacing)
 
             if self._label_text is not None and self._label_text != "":
                 self._label.grid(row=0, column=0, columnspan=2, sticky="ew", padx=border_spacing, pady=border_spacing)

--- a/customtkinter/windows/widgets/ctk_scrollable_frame.py
+++ b/customtkinter/windows/widgets/ctk_scrollable_frame.py
@@ -100,7 +100,7 @@ class CTkScrollableFrame(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBa
         border_spacing = self._apply_widget_scaling(self._parent_frame.cget("corner_radius") + self._parent_frame.cget("border_width"))
 
         if self._orientation == "horizontal":
-            border_padding = self._border_width*2
+            border_padding = (0, self._border_width +1)
             self._parent_frame.grid_columnconfigure(0, weight=1)
             self._parent_frame.grid_rowconfigure(1, weight=1)
             self._parent_canvas.grid(row=1, column=0, sticky="nsew", padx=border_spacing, pady=(border_spacing, 0))
@@ -112,7 +112,7 @@ class CTkScrollableFrame(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBa
                 self._label.grid_forget()
 
         elif self._orientation == "vertical":
-            border_padding = self._border_width*2
+            border_padding = (0, self._border_width +1)
             self._parent_frame.grid_columnconfigure(0, weight=1)
             self._parent_frame.grid_rowconfigure(1, weight=1)
             self._parent_canvas.grid(row=1, column=0, sticky="nsew", padx=(border_spacing, 0), pady=border_spacing)


### PR DESCRIPTION
First the issue appeared in https://github.com/TomSchimansky/CustomTkinter/issues/2542. I provided the solution on as https://github.com/TomSchimansky/CustomTkinter/issues/2542#issuecomment-2295239302. More enhanced form of the solution code is pulled.

Problem View:
![Scrollbar_Before](https://github.com/user-attachments/assets/36ac87ce-0533-434b-ac23-f9ebf19312f8)

Solved View:
![Scrollbar_After](https://github.com/user-attachments/assets/070d3611-49ec-4a9b-bc9c-e7bf1899ba30)