### PR TITLE
Update ctk_toplevel.py

### DIFF
--- a/customtkinter/windows/ctk_toplevel.py
+++ b/customtkinter/windows/ctk_toplevel.py
@@ -42,7 +42,8 @@ class CTkToplevel(tkinter.Toplevel, CTkAppearanceModeBaseClass, CTkScalingBaseCl
             # Set Windows titlebar icon
             if sys.platform.startswith("win"):
                 customtkinter_directory = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-                self.after(200, lambda: self.iconbitmap(os.path.join(customtkinter_directory, "assets", "icons", "CustomTkinter_icon_Windows.ico")))
+                # self.after(200, lambda: self.iconbitmap(os.path.join(customtkinter_directory, "assets", "icons", "CustomTkinter_icon_Windows.ico")))
+                self.iconbitmap(os.path.join(customtkinter_directory, "assets", "icons", "CustomTkinter_icon_Windows.ico")) # .. It is not necessary to use self.alter and it can be removed.
         except Exception:
             pass
 


### PR DESCRIPTION
There is no need to use self.alter when uploading an icon to toplevel, and it can be deleted.