### PR TITLE
Fix: allow CTkSwitch.configure() to accept 'onvalue' and 'offvalue'

### DIFF
--- a/customtkinter/windows/widgets/ctk_switch.py
+++ b/customtkinter/windows/widgets/ctk_switch.py
@@ -255,6 +255,12 @@ class CTkSwitch(CTkBaseClass):
             self._text_label.configure(bg=self._apply_appearance_mode(self._bg_color))
 
     def configure(self, require_redraw=False, **kwargs):
+        if "onvalue" in kwargs:
+             self._onvalue = kwargs.pop("onvalue")
+
+        if "offvalue" in kwargs:
+             self._offvalue = kwargs.pop("offvalue")
+
         if "corner_radius" in kwargs:
             self._corner_radius = kwargs.pop("corner_radius")
             require_redraw = True


### PR DESCRIPTION
### Description

This pull request fixes an issue in the `CTkSwitch` widget where the `onvalue` and `offvalue` parameters could only be set during initialization, but not via the `configure()` method.

Trying to use `.configure(onvalue=..., offvalue=...)` would raise a `ValueError` due to missing handling for those parameters in the method.

### Reproduction

```python
import customtkinter

root = customtkinter.CTk()
s = customtkinter.CTkSwitch(root)
s.configure(onvalue='manual', offvalue='automatic')  # 💥 ValueError before this fix
s.pack()
root.mainloop()
```

### Fix

I added handling for `onvalue` and `offvalue` inside the `configure()` method of `CTkSwitch`, following the same pattern used for other supported keyword arguments like `text`, `state`, and `variable`.
Let me know if I should add test cases or adjust anything.