### PR TITLE
Feat: Add compatibility for Python 3.6

### DIFF
--- a/customtkinter/windows/widgets/core_rendering/draw_engine.py
+++ b/customtkinter/windows/widgets/core_rendering/draw_engine.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import sys
 import math
 import tkinter
@@ -28,7 +27,7 @@ class DrawEngine:
 
     preferred_drawing_method: str = None  # 'polygon_shapes', 'font_shapes', 'circle_shapes'
 
-    def __init__(self, canvas: CTkCanvas):
+    def __init__(self, canvas):
         self._canvas = canvas
         self._round_width_to_even_numbers: bool = True
         self._round_height_to_even_numbers: bool = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 darkdetect~=0.3.1
 typing-extensions~=4.4.0
 packaging
+typing_extensions


### PR DESCRIPTION
Closes #2729

### Summary
This PR introducing backward compatibility for Python 3.6 without damaging all the current features. You can do it manually via the following steps:

1. Download the ZIP of this repository.
2. Open it and extract the 'customtkinter' folder to your working directory.
3. Do the changes in this PR.
4. Install 'typing_extensions' library to your environment.

Now you can enjoy the modern-UI provided by CustomTkinter!