### PR TITLE
fix: Add missing scaling base class destroy in dropdown_menu.

### DIFF
--- a/customtkinter/windows/widgets/core_widget_classes/dropdown_menu.py
+++ b/customtkinter/windows/widgets/core_widget_classes/dropdown_menu.py
@@ -50,6 +50,7 @@ class DropdownMenu(tkinter.Menu, CTkAppearanceModeBaseClass, CTkScalingBaseClass
         # call destroy methods of super classes
         tkinter.Menu.destroy(self)
         CTkAppearanceModeBaseClass.destroy(self)
+        CTkScalingBaseClass.destroy(self)
 
     def _update_font(self):
         """ pass font to tkinter widgets with applied font scaling """


### PR DESCRIPTION
This PR solves the issue where a frame containing DropdownMenu is destroyed and recreated, then the window is scaled.

This PR adds a missing cleanup statement to `dropdown_menu.py`.

```
class DropdownMenu(tkinter.Menu, CTkAppearanceModeBaseClass, CTkScalingBaseClass):
    def __init__(self, *args,
                 min_character_width: int = 18,
                 fg_color: Optional[Union[str, Tuple[str, str]]] = None,
                 hover_color: Optional[Union[str, Tuple[str, str]]] = None,
                 text_color: Optional[Union[str, Tuple[str, str]]] = None,
                 font: Optional[Union[tuple, CTkFont]] = None,
                 command: Union[Callable, None] = None,
                 values: Optional[List[str]] = None,
                 **kwargs):
        # call init methods of super classes
        tkinter.Menu.__init__(self, *args, **kwargs)
        CTkAppearanceModeBaseClass.__init__(self)
        CTkScalingBaseClass.__init__(self, scaling_type="widget")
```

but destroy missing call to `CTkScalingBaseClass.destroy(self)`

```
    def destroy(self):
        if isinstance(self._font, CTkFont):
            self._font.remove_size_configure_callback(self._update_font)
        # call destroy methods of super classes
        tkinter.Menu.destroy(self)
        CTkAppearanceModeBaseClass.destroy(self)
        # fix missing
```
