### PR TITLE
Added feature (orientation= 'both') and fixed padding issues

### DIFF
--- a/customtkinter/windows/widgets/ctk_scrollable_frame.py
+++ b/customtkinter/windows/widgets/ctk_scrollable_frame.py
@@ -36,7 +36,7 @@ class CTkScrollableFrame(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBa
                  label_text: str = "",
                  label_font: Optional[Union[tuple, CTkFont]] = None,
                  label_anchor: str = "center",
-                 orientation: Literal["vertical", "horizontal"] = "vertical"):
+                 orientation: Literal["vertical", "horizontal", "both"] = "vertical"):
 
         self._orientation = orientation
 
@@ -58,7 +58,15 @@ class CTkScrollableFrame(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBa
             self._scrollbar = CTkScrollbar(master=self._parent_frame, orientation="vertical", command=self._parent_canvas.yview,
                                            fg_color=scrollbar_fg_color, button_color=scrollbar_button_color, button_hover_color=scrollbar_button_hover_color)
             self._parent_canvas.configure(yscrollcommand=self._scrollbar.set)
+        elif self._orientation == "both":
+            self._scrollbar = CTkScrollbar(master=self._parent_frame, orientation="vertical", command=self._parent_canvas.yview,
+                                            fg_color=scrollbar_fg_color, button_color=scrollbar_button_color, button_hover_color=scrollbar_button_hover_color)
+            self._parent_canvas.configure(yscrollcommand=self._scrollbar.set)
 
+            self._h_scrollbar = CTkScrollbar(master=self._parent_frame, orientation="horizontal", command=self._parent_canvas.xview,
+                                            fg_color=scrollbar_fg_color, button_color=scrollbar_button_color, button_hover_color=scrollbar_button_hover_color)
+            self._parent_canvas.configure(xscrollcommand=self._h_scrollbar.set)
+        
         self._label_text = label_text
         self._label = CTkLabel(self._parent_frame, text=label_text, anchor=label_anchor, font=label_font,
                                corner_radius=self._parent_frame.cget("corner_radius"), text_color=label_text_color,
@@ -98,16 +106,16 @@ class CTkScrollableFrame(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBa
 
     def _create_grid(self):
         border_spacing = self._apply_widget_scaling(self._parent_frame.cget("corner_radius") + self._parent_frame.cget("border_width"))
-
+        constant_spacing = 2
         if self._orientation == "horizontal":
             border_padding = (0, self._border_width +1)
             self._parent_frame.grid_columnconfigure(0, weight=1)
             self._parent_frame.grid_rowconfigure(1, weight=1)
-            self._parent_canvas.grid(row=1, column=0, sticky="nsew", padx=border_spacing, pady=(border_spacing, 0))
+            self._parent_canvas.grid(row=1, column=0, sticky="nsew", padx=border_spacing)
             self._scrollbar.grid(row=2, column=0, sticky="nsew", padx=border_spacing, pady=border_padding)
 
             if self._label_text is not None and self._label_text != "":
-                self._label.grid(row=0, column=0, sticky="ew", padx=border_spacing, pady=border_spacing)
+                self._label.grid(row=0, column=0, sticky="ew", padx=border_spacing, pady=(border_spacing, constant_spacing))
             else:
                 self._label.grid_forget()
 
@@ -115,11 +123,24 @@ class CTkScrollableFrame(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBa
             border_padding = (0, self._border_width +1)
             self._parent_frame.grid_columnconfigure(0, weight=1)
             self._parent_frame.grid_rowconfigure(1, weight=1)
-            self._parent_canvas.grid(row=1, column=0, sticky="nsew", padx=(border_spacing, 0), pady=border_spacing)
-            self._scrollbar.grid(row=1, column=1, sticky="nsew", padx=border_padding, pady=border_spacing)
+            self._parent_canvas.grid(row=1, column=0, sticky="nsew", padx=(border_spacing, constant_spacing), pady=( constant_spacing, border_spacing))
+            self._scrollbar.grid(row=1, column=1, sticky="nsew", padx=border_padding, pady=( constant_spacing, border_spacing))
 
             if self._label_text is not None and self._label_text != "":
-                self._label.grid(row=0, column=0, columnspan=2, sticky="ew", padx=border_spacing, pady=border_spacing)
+                self._label.grid(row=0, column=0, columnspan=2, sticky="ew", padx=border_spacing, pady=(border_spacing, constant_spacing))
+            else:
+                self._label.grid_forget()
+
+        elif self._orientation == "both":
+            border_padding = (0, self._border_width +1)
+            self._parent_frame.grid_columnconfigure(0, weight=1)
+            self._parent_frame.grid_rowconfigure(1, weight=1)
+            self._parent_canvas.grid(row=1, column=0, sticky="nsew", padx=(border_spacing, constant_spacing), pady=constant_spacing)
+            self._scrollbar.grid(row=1, column=1, sticky="nsew", padx=border_padding, pady=constant_spacing)
+            self._h_scrollbar.grid(row=2, column=0, sticky="nsew", padx=(border_spacing, constant_spacing), pady=border_padding)
+
+            if self._label_text is not None and self._label_text != "":
+                self._label.grid(row=0, column=0, columnspan=2, sticky="ew", padx=border_spacing, pady=(border_spacing, constant_spacing))
             else:
                 self._label.grid_forget()
 
@@ -241,6 +262,8 @@ class CTkScrollableFrame(tkinter.Frame, CTkAppearanceModeBaseClass, CTkScalingBa
             self._parent_canvas.itemconfigure(self._create_window_id, height=self._parent_canvas.winfo_height())
         elif self._orientation == "vertical":
             self._parent_canvas.itemconfigure(self._create_window_id, width=self._parent_canvas.winfo_width())
+        elif self._orientation == "both":
+            self._parent_canvas.itemconfigure(self._create_window_id)
 
     def _set_scroll_increments(self):
         if sys.platform.startswith("win"):


### PR DESCRIPTION
# ✨ Added Feature: `orientation="both"`

## Summary

Added support for `orientation="both"` to allow simultaneous horizontal and vertical scrolling.

Previously, widgets only supported:

* `"vertical"`
* `"horizontal"`

Now users can use:

```python
orientation="both"
```

to enable scrolling in both directions.

---

## Example Usage

```python
scrollable_frame = customtkinter.CTkScrollableFrame(
    master=app,
    orientation="both"
)
scrollable_frame.pack()
```

This allows content larger than the container to scroll both vertically and horizontally.
<img width="280" height="355" alt="feature1" src="https://github.com/user-attachments/assets/35a446e0-3d39-4b46-a9dc-6fa1a8a1007d" />

---

## Behavior

* `"vertical"` → vertical scrollbar only
* `"horizontal"` → horizontal scrollbar only
* `"both"` → both scrollbars appear when needed

Backward compatibility is preserved.
Existing code using `"vertical"` or `"horizontal"` works unchanged.

---

# 🛠 Fix: Border_width

## Issue
when user increase Border_width empty space between label and canvas increase automatically.
## Before
<img width="896" height="701" alt="before1" src="https://github.com/user-attachments/assets/fed55def-92e8-41d5-b92b-f0e57f52c1f1" />


## After
<img width="899" height="584" alt="pro2" src="https://github.com/user-attachments/assets/380bdb0f-22ab-4e6a-a24d-68581be8a2bb" />

---
## Combine:
<img width="1357" height="564" alt="pro1" src="https://github.com/user-attachments/assets/04390b12-fa8d-4642-af39-a03ab23e9089" />

---

# ✅ Why This Improvement Is Useful

* Enables more flexible scrollable layouts
* Fixes inconsistency in border_width
* Maintains full backward compatibility
---
# Test script
```python
import customtkinter as ctk

root = ctk.CTk()
root.geometry("1400x550")
root.title('Scroll Frame test')

vertical_sfrm = ctk.CTkScrollableFrame(root, orientation="vertical", label_text='Vertical', border_width=100, border_color='orange',
                                       scrollbar_fg_color='green',
                                       scrollbar_button_color='yellow',
                                       scrollbar_button_hover_color='blue')
vertical_sfrm.pack(side='left', padx=(20, 0))

horizontal_sfrm = ctk.CTkScrollableFrame(root, orientation="horizontal", label_text='Horizontal', border_width=100, border_color='orange', scrollbar_fg_color='green')
horizontal_sfrm.pack(side='left', padx=(20, 0))

both_sfrm = ctk.CTkScrollableFrame(root, orientation="both", label_text='Both Side', border_width=100, border_color='orange', scrollbar_fg_color='green')
both_sfrm.pack(side='left', padx=(20, 0))

grid = 10
for row in range(grid):
    row_frm = ctk.CTkFrame(vertical_sfrm)
    row_frm.pack()
    for col in range(grid):
        label = ctk.CTkLabel(row_frm, text=f"label no: {row}x{col}.")
        label.pack(side='left')


for row in range(grid):
    row_frm = ctk.CTkFrame(horizontal_sfrm)
    row_frm.pack()
    for col in range(grid):
        label = ctk.CTkLabel(row_frm, text=f"label no: {row}x{col}.")
        label.pack(side='left')


for row in range(grid):
    row_frm = ctk.CTkFrame(both_sfrm)
    row_frm.pack()
    for col in range(grid):
        label = ctk.CTkLabel(row_frm, text=f"label no: {row}x{col}.")
        label.pack(side='left')

root.mainloop()
```