### PR TITLE
fix: save window state before withdraw in _windows_set_titlebar_color when window not yet shown

### DIFF
--- a/customtkinter/windows/ctk_tk.py
+++ b/customtkinter/windows/ctk_tk.py
@@ -278,6 +278,7 @@ class CTk(CTK_PARENT_CLASS, CTkAppearanceModeBaseClass, CTkScalingBaseClass):
                     super().withdraw()  # hide window so that it can be redrawn after the titlebar change so that the color change is visible
             else:
                 # print("window dont exists -> withdraw and update")
+                self._state_before_windows_set_titlebar_color = self.state()
                 self.focused_widget_before_widthdraw = self.focus_get()
                 super().withdraw()
                 super().update()


### PR DESCRIPTION
Fixes #2810

## Problem
When `withdraw()` is called before `mainloop()`, `_state_before_windows_set_titlebar_color`
was never assigned in the `else` branch of `_windows_set_titlebar_color()`, remaining `None`.

The restore block then executed `self.state(None)` which is a no-op (query only),
leaving the window permanently hidden after the titlebar color change.

## Fix
Save `self.state()` before calling `super().withdraw()` in the `else` branch,
mirroring what the `if self._window_exists` branch already does correctly.

## Change
1 line added in `_windows_set_titlebar_color()` — no behavior change for existing working paths.
