### PR TITLE
Fix optionmenu destroy

### DIFF
--- a/customtkinter/windows/widgets/core_widget_classes/dropdown_menu.py
+++ b/customtkinter/windows/widgets/core_widget_classes/dropdown_menu.py
@@ -47,6 +47,9 @@ class DropdownMenu(tkinter.Menu, CTkAppearanceModeBaseClass, CTkScalingBaseClass
         if isinstance(self._font, CTkFont):
             self._font.remove_size_configure_callback(self._update_font)
 
+        # Remove the scaling callback before destroying the underlying Tk menu.
+        CTkScalingBaseClass.destroy(self)
+
         # call destroy methods of super classes
         tkinter.Menu.destroy(self)
         CTkAppearanceModeBaseClass.destroy(self)

--- a/customtkinter/windows/widgets/ctk_optionmenu.py
+++ b/customtkinter/windows/widgets/ctk_optionmenu.py
@@ -174,6 +174,14 @@ class CTkOptionMenu(CTkBaseClass):
         self._canvas.grid(row=0, column=0, sticky="nsew")
 
     def destroy(self):
+        # The dropdown menu is a separate Tk widget and must be destroyed explicitly.
+        if self._dropdown_menu is not None:
+            try:
+                self._dropdown_menu.destroy()
+            except tkinter.TclError:
+                pass
+            self._dropdown_menu = None
+
         if self._variable is not None:  # remove old callback
             self._variable.trace_remove("write", self._variable_callback_name)
 


### PR DESCRIPTION
Apparently this fixes the problems with scaling and the CtkOptionMenu.destroy() (see Issue #2813).

Hope this helps :)