### PR TITLE
Fix: disabled CTkEntry placeholder becoming an actual value

### DIFF
--- a/customtkinter/windows/widgets/ctk_entry.py
+++ b/customtkinter/windows/widgets/ctk_entry.py
@@ -313,7 +313,7 @@ class CTkEntry(CTkBaseClass):
             self._entry.insert(0, self._placeholder_text)
 
     def _deactivate_placeholder(self):
-        if self._placeholder_text_active and self._entry.cget("state") != "readonly":
+        if self._placeholder_text_active and self._entry.cget("state") not in ("disabled", "readonly"):
             self._placeholder_text_active = False
 
             self._entry.config(fg=self._apply_appearance_mode(self._text_color),


### PR DESCRIPTION
## Problem

When a CTkEntry with an active placeholder is disabled and clicked, its
placeholder is deactivated. Because the underlying tkinter.Entry cannot delete
text while disabled, the placeholder remains and is returned as an actual value
after the entry is enabled again.

## Fix

Prevent placeholder deactivation when the entry state is either `disabled` or
`readonly`.

## Testing

Verified locally with this sequence:

1. Create an entry with a placeholder.
2. Disable and click the entry.
3. Enable the entry again.
4. Confirm that `get()` returns an empty string instead of the placeholder.

The local regression test passed.